### PR TITLE
Remove 'Lucky Dip' nav; add proof/freshness UI, top-picks feed and refresh/error handling

### DIFF
--- a/Test.html
+++ b/Test.html
@@ -634,8 +634,7 @@
     .bottom-nav a[data-key="home"] .label       { content: "Home"; }
     .bottom-nav a[data-key="hda"] .label        { content: "Winner"; }
     .bottom-nav a[data-key="uo"] .label         { content: "U/O 2.5"; }
-    .bottom-nav a[data-key="lucky"] .label      { content: "Lucky"; }
-    .bottom-nav a[data-key="historical"] .label { content: "History"; }
+        .bottom-nav a[data-key="historical"] .label { content: "History"; }
     .bottom-nav a[data-key="faqs"] .label       { content: "FAQs"; }
 
     /* --------------------------------------------------
@@ -733,7 +732,6 @@
         <a href="/index" class="active">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -937,10 +935,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>

--- a/Test2.html
+++ b/Test2.html
@@ -643,7 +643,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -762,10 +761,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/faqs.html
+++ b/faqs.html
@@ -18,7 +18,6 @@
     <a href="/index">HOME</a>
     <a href="/hda-value">MATCH RESULT</a>
     <a href="/uo-value">UNDER/OVER 2.5</a>
-    <a href="/lucky-dip">LUCKY DIP</a>
     <a href="/historical">HISTORICAL DATA</a>
     <a href="/faqs" class="active">FAQs</a>
   </nav>

--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -337,6 +337,23 @@
       color: #8c8c8e;
     }
 
+
+    .proof-strip {
+      margin: 6px 0 12px;
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(24, 24, 26, 0.96);
+      border: 1px solid rgba(255,255,255,0.08);
+      display: grid;
+      gap: 8px;
+    }
+    .proof-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: #f7b057; }
+    .proof-items { margin: 0; padding-left: 18px; display: grid; gap: 4px; font-size: 12px; color: #d9d9d9; }
+    .proof-items a { color: #f7b057; }
+    .freshness-inline { margin-top: 6px; font-size: 12px; color: #cfcfcf; }
+    .cadence-row { display:flex; flex-wrap:wrap; gap:8px; }
+    .cadence-chip { font-size:11px; border:1px solid rgba(240,147,0,.45); padding:4px 8px; border-radius:999px; color:#e8c08c; }
+
     /* Footer */
     .home-footer {
       margin-top: 18px;
@@ -581,7 +598,7 @@
     <p class="loading-subtitle">
       We&#39;re surfacing the fixtures where the model sees the strongest chances for a result.
     </p>
-    <div class="loading-ticker">Loading match data...</div>
+    <div class="loading-ticker">Fetching latest sheet data...</div>
   </div>
 
   <div class="home-page">
@@ -609,7 +626,6 @@
         <a href="/index">Home</a>
         <a href="/hda-highchance" class="active">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -620,6 +636,18 @@
         <a href="/hda-highchance" class="active">Highest Chance</a>
       </div>
     </header>
+
+
+    <section class="proof-strip" aria-label="Trust and methodology notes">
+      <p class="proof-title">Before you use these picks</p>
+      <ul class="proof-items">
+        <li>Compare today's picks with <a href="/historical">Historical Data</a> and the <a href="/faqs">FAQ methodology</a>.</li>
+        <li>Data source: live model output and bookmaker prices from linked Google Sheets.</li>
+        <li>Value compares model chance vs market chance — it is not a guarantee on a single fixture.</li>
+      </ul>
+      <p class="freshness-inline">Last refreshed: <strong id="refresh-time">Loading…</strong> (page data refresh time).</p>
+      <div class="cadence-row"><span class="cadence-chip">Friday shortlist</span><span class="cadence-chip">Weekend picks</span><span class="cadence-chip">Monday review</span></div>
+    </section>
 
     <!-- Main data layout -->
     <section class="data-layout">
@@ -692,10 +720,6 @@
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
     </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
-    </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>
       <span class="label">History</span>
@@ -718,6 +742,12 @@
       // Simple CSV split; assumes your sheet cells don't contain unescaped commas/newlines.
       return text.trim().split("\n").map(r => r.split(","));
     }
+
+    function formatRefreshTime(d){ return d.toLocaleString("en-GB", { day:"2-digit", month:"short", hour:"2-digit", minute:"2-digit", hour12:false, timeZone:"UTC" }) + " UTC"; }
+
+    function setRefreshNow(){ const el=document.getElementById("refresh-time"); if(el){ el.textContent=formatRefreshTime(new Date()); } }
+
+    function showLoadError(){ const container=document.getElementById("sheet-data"); if(container){ container.innerHTML="<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn\'t load the live data just now. Please refresh in a minute.</p>"; } }
 
     function hideLoadingOverlay() {
       const overlay = document.getElementById("loadingOverlay");
@@ -746,12 +776,10 @@
         buildDayButtons();
         attachResultButtonHandlers();
         renderTable();
+        setRefreshNow();
       } catch (err) {
         console.error("Error loading CSV:", err);
-        const container = document.getElementById("sheet-data");
-        if (container) {
-          container.innerHTML = "<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn&#39;t load today&#39;s data. Please refresh the page in a moment.</p>";
-        }
+        showLoadError();
       } finally {
         hideLoadingOverlay();
       }

--- a/hda-histd.html
+++ b/hda-histd.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>MC PREDICT - MATCH WINNER HISTORICAL PREDICTIONS</title>
+  <title>MC PREDICT - MATCH RESULT HISTORICAL PREDICTIONS (DECIMAL)</title>
 
   <!-- jQuery -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
@@ -643,7 +643,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -659,7 +658,7 @@
     <section class="data-layout">
       <div class="data-main-card">
         <div class="data-eyebrow">Match Result</div>
-        <h2 class="data-title">Historical predictions – fractional odds</h2>
+        <h2 class="data-title">Historical predictions – decimal odds</h2>
         <p class="data-subtitle">
           Explore every historical match result prediction, including prices, value rating and outcome.
         </p>
@@ -760,10 +759,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/hda-histf.html
+++ b/hda-histf.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>MC PREDICT - MATCH WINNER HISTORICAL PREDICTIONS</title>
+  <title>MC PREDICT - MATCH RESULT HISTORICAL PREDICTIONS (FRACTIONAL)</title>
 
   <!-- jQuery -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
@@ -644,7 +644,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -761,10 +760,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/hda-results.html
+++ b/hda-results.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>MC PREDICT - MATCH WINNER BEST VALUE (Historical)</title>
+  <title>MC PREDICT - MATCH RESULT BEST VALUE (Historical)</title>
 
   <!-- Fonts + global stylesheet -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -464,7 +464,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -516,10 +515,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/hda-value.html
+++ b/hda-value.html
@@ -328,6 +328,23 @@
       color: #8c8c8e;
     }
 
+
+    .proof-strip {
+      margin: 6px 0 12px;
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(24, 24, 26, 0.96);
+      border: 1px solid rgba(255,255,255,0.08);
+      display: grid;
+      gap: 8px;
+    }
+    .proof-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: #f7b057; }
+    .proof-items { margin: 0; padding-left: 18px; display: grid; gap: 4px; font-size: 12px; color: #d9d9d9; }
+    .proof-items a { color: #f7b057; }
+    .freshness-inline { margin-top: 6px; font-size: 12px; color: #cfcfcf; }
+    .cadence-row { display:flex; flex-wrap:wrap; gap:8px; }
+    .cadence-chip { font-size:11px; border:1px solid rgba(240,147,0,.45); padding:4px 8px; border-radius:999px; color:#e8c08c; }
+
     /* Footer */
     .home-footer {
       margin-top: 18px;
@@ -572,7 +589,7 @@
     <p class="loading-subtitle">
       We&#39;re lining up today&#39;s best value fixtures based on the latest model and market prices.
     </p>
-    <div class="loading-ticker">Loading match data...</div>
+    <div class="loading-ticker">Fetching latest sheet data...</div>
   </div>
 
   <div class="home-page">
@@ -600,7 +617,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value" class="active">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -611,6 +627,18 @@
         <a href="/hda-highchance">Highest Chance</a>
       </div>
     </header>
+
+
+    <section class="proof-strip" aria-label="Trust and methodology notes">
+      <p class="proof-title">Before you use these picks</p>
+      <ul class="proof-items">
+        <li>Compare today's picks with <a href="/historical">Historical Data</a> and the <a href="/faqs">FAQ methodology</a>.</li>
+        <li>Data source: live model output and bookmaker prices from linked Google Sheets.</li>
+        <li>Value compares model chance vs market chance — it is not a guarantee on a single fixture.</li>
+      </ul>
+      <p class="freshness-inline">Last refreshed: <strong id="refresh-time">Loading…</strong> (page data refresh time).</p>
+      <div class="cadence-row"><span class="cadence-chip">Friday shortlist</span><span class="cadence-chip">Weekend picks</span><span class="cadence-chip">Monday review</span></div>
+    </section>
 
     <!-- Main data layout -->
     <section class="data-layout">
@@ -685,10 +713,6 @@
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
     </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
-    </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>
       <span class="label">History</span>
@@ -711,6 +735,12 @@
       // Simple CSV split; assumes your sheet cells don't contain unescaped commas/newlines.
       return text.trim().split("\n").map(r => r.split(","));
     }
+
+    function formatRefreshTime(d){ return d.toLocaleString("en-GB", { day:"2-digit", month:"short", hour:"2-digit", minute:"2-digit", hour12:false, timeZone:"UTC" }) + " UTC"; }
+
+    function setRefreshNow(){ const el=document.getElementById("refresh-time"); if(el){ el.textContent=formatRefreshTime(new Date()); } }
+
+    function showLoadError(){ const container=document.getElementById("sheet-data"); if(container){ container.innerHTML="<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn\'t load the live data just now. Please refresh in a minute.</p>"; } }
 
     function hideLoadingOverlay() {
       const overlay = document.getElementById("loadingOverlay");
@@ -739,12 +769,10 @@
         buildDayButtons();
         attachResultButtonHandlers();
         renderTable();
+        setRefreshNow();
       } catch (err) {
         console.error("Error loading CSV:", err);
-        const container = document.getElementById("sheet-data");
-        if (container) {
-          container.innerHTML = "<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn&#39;t load today&#39;s data. Please refresh the page in a moment.</p>";
-        }
+        showLoadError();
       } finally {
         hideLoadingOverlay();
       }

--- a/historical.html
+++ b/historical.html
@@ -393,7 +393,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -461,10 +460,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/index.html
+++ b/index.html
@@ -551,9 +551,34 @@
     .bottom-nav a[data-key="home"] .label       { content: "Home"; }
     .bottom-nav a[data-key="hda"] .label        { content: "Winner"; }
     .bottom-nav a[data-key="uo"] .label         { content: "U/O 2.5"; }
-    .bottom-nav a[data-key="lucky"] .label      { content: "Lucky"; }
-    .bottom-nav a[data-key="historical"] .label { content: "History"; }
+        .bottom-nav a[data-key="historical"] .label { content: "History"; }
     .bottom-nav a[data-key="faqs"] .label       { content: "FAQs"; }
+
+
+
+    .freshness-strip,
+    .top-picks-hub {
+      background: rgba(24, 24, 26, 0.92);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 14px;
+    }
+    .freshness-strip { display:grid; gap:8px; margin-top:8px; }
+    .freshness-title { font-size:12px; letter-spacing:.08em; text-transform:uppercase; color:#f7b057; margin:0; }
+    .freshness-note { margin:0; font-size:13px; color:#d8d8d8; }
+    .cadence-row { display:flex; flex-wrap:wrap; gap:8px; }
+    .cadence-chip { font-size:11px; border:1px solid rgba(240,147,0,.45); padding:5px 9px; border-radius:999px; color:#e8c08c; }
+    .top-picks-head { display:flex; flex-direction:column; gap:4px; margin-bottom:10px; }
+    .top-picks-title { margin:0; color:#fff; font-size:20px; }
+    .top-picks-subtitle { margin:0; font-size:13px; color:#bdbdbd; }
+    .top-picks-grid { display:grid; grid-template-columns:1fr; gap:10px; }
+    .pick-card { background:rgba(39,39,41,.95); border:1px solid rgba(255,255,255,.08); border-radius:14px; padding:12px; display:grid; gap:8px; }
+    .pick-meta { display:flex; justify-content:space-between; gap:8px; font-size:11px; color:#cfcfcf; text-transform:uppercase; letter-spacing:.06em; }
+    .pick-fixture { color:#fff; font-size:15px; font-weight:700; }
+    .pick-line { font-size:13px; color:#d7d7d7; }
+    .pick-prices { display:flex; gap:8px; flex-wrap:wrap; font-size:12px; }
+    .pick-badge { display:inline-flex; align-items:center; padding:5px 8px; border-radius:999px; font-size:11px; color:#111; background:linear-gradient(135deg,#f09300,#ffae33); font-weight:700; width:fit-content; }
+    .pick-cta { width:fit-content; font-size:12px; color:#f7b057; }
 
     /* --------------------------------------------------
        Responsive
@@ -650,7 +675,6 @@
         <a href="/index" class="active">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -775,6 +799,27 @@
       </aside>
     </section>
 
+
+
+    <section class="freshness-strip" aria-label="Refresh and update cadence">
+      <p class="freshness-title">Data refresh cadence</p>
+      <p class="freshness-note">Last refreshed: <strong id="home-refresh-time">Loading…</strong> (page data refresh time).</p>
+      <div class="cadence-row">
+        <span class="cadence-chip">Friday: shortlist review</span>
+        <span class="cadence-chip">Weekend: live picks focus</span>
+        <span class="cadence-chip">Monday: results review</span>
+      </div>
+    </section>
+
+    <section class="top-picks-hub" aria-live="polite">
+      <div class="top-picks-head">
+        <h3 class="top-picks-title">Top Picks Today / This Weekend</h3>
+        <p class="top-picks-subtitle">Best-value cards from Match Result and Under/Over 2.5 feeds.</p>
+      </div>
+      <div id="top-picks-status" class="top-picks-subtitle">Loading actionable picks…</div>
+      <div id="top-picks-grid" class="top-picks-grid"></div>
+    </section>
+
     <!-- Quick start / what’s under the hood -->
     <section class="quick-start" aria-label="How to use MC Predict">
       <div class="quick-start-card">
@@ -839,10 +884,6 @@
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
     </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
-    </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>
       <span class="label">History</span>
@@ -852,5 +893,76 @@
       <span class="label">FAQs</span>
     </a>
   </nav>
+
+  <script>
+    function formatRefreshTime(d){return d.toLocaleString("en-GB",{day:"2-digit",month:"short",hour:"2-digit",minute:"2-digit",hour12:false,timeZone:"UTC"})+" UTC";}
+    function parseCSVLine(line){const out=[];let cur="",q=false;for(let i=0;i<line.length;i++){const ch=line[i];if(q&&ch==='"'&&line[i+1]==='"'){cur+='"';i++;continue;}if(ch==='"'){q=!q;continue;}if(ch===','&&!q){out.push(cur.trim());cur="";continue;}cur+=ch;}out.push(cur.trim());return out;}
+    function parseCSV(text){return text.trim().split(/\r?\n/).map(parseCSVLine);}
+    function normalizeHeader(v){return (v||"").toLowerCase().replace(/[^a-z0-9]/g,"");}
+    function mapHeaders(headers){const m={};headers.forEach((v,i)=>{const key=normalizeHeader(v);if(key&&!m[key]) m[key]=i;});return m;}
+    function get(row,map,names){for(const n of names){const key=normalizeHeader(n);if(map[key]!==undefined&&row[map[key]]) return row[map[key]].trim();}return "";}
+    function score(v){return (v.match(/💰/g)||[]).length-(v.match(/❌/g)||[]).length;}
+
+    async function loadFeed(feed){
+      const res = await fetch(feed.url,{cache:"no-store"});
+      if(!res.ok) throw new Error(`Feed failed: ${feed.market}`);
+      const rows = parseCSV(await res.text()).filter(r => r.some(c => (c||"").trim()));
+      const map = mapHeaders(rows[1] || []);
+      return rows.slice(2).map((row) => {
+        const value = get(row,map,["value","value rating","valuerating"]);
+        const fixture = get(row,map,["fixture","match","teams","homevaway"]);
+        const pick = get(row,map,["prediction","pick","result","selection"]);
+        return {
+          market: feed.market,
+          page: feed.page,
+          fixture: fixture || "Fixture TBC",
+          pick: pick || "Pick unavailable",
+          day: get(row,map,["day","date","matchday"]),
+          bo: get(row,map,["bookies odds","bookmaker price","bo","bookiesodds"]),
+          mo: get(row,map,["model odds","model price","mo","modelodds"]),
+          value: value || "—",
+          score: score(value || "")
+        };
+      }).filter(p => p.fixture !== "Fixture TBC" || p.pick !== "Pick unavailable");
+    }
+
+    async function loadTopPicks(){
+      const refreshEl = document.getElementById("home-refresh-time");
+      const status = document.getElementById("top-picks-status");
+      const grid = document.getElementById("top-picks-grid");
+      const feeds=[
+        {market:"Match Result",page:"/hda-value",url:"https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=772292951&single=true&output=csv"},
+        {market:"Under/Over 2.5",page:"/uo-value",url:"https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=702828084&single=true&output=csv"}
+      ];
+
+      const results = await Promise.allSettled(feeds.map(loadFeed));
+      const successfulFeeds = results.filter(r => r.status === "fulfilled");
+      const successful = successfulFeeds.map(r => r.value).flat();
+      const failures = results.filter(r => r.status === "rejected").length;
+
+      if (!successfulFeeds.length) {
+        status.textContent = "We couldn't load top picks right now. Please refresh in a moment.";
+        grid.innerHTML = "";
+        refreshEl.textContent = "Unavailable (last fetch failed)";
+        return;
+      }
+
+      refreshEl.textContent = `${formatRefreshTime(new Date())} (page data refresh time)`;
+      const selected = successful.sort((a,b)=>b.score-a.score).slice(0,5);
+      if (!selected.length) {
+        status.textContent = "Data loaded, but there are no qualifying picks available right now.";
+        grid.innerHTML = "";
+        return;
+      }
+      status.textContent = failures ? "Some feeds are temporarily unavailable. Showing available picks." : "";
+      grid.innerHTML = selected.map(p=>`<article class="pick-card"><div class="pick-meta"><span>${p.market}</span><span>${p.day||"Day TBC"}</span></div><div class="pick-fixture">${p.fixture}</div><div class="pick-line">Pick: <strong>${p.pick}</strong></div><div class="pick-prices"><span>Bookmaker: <strong>${p.bo||"—"}</strong></span><span>Model: <strong>${p.mo||"—"}</strong></span></div><div class="pick-badge">${p.value}</div><a class="pick-cta" href="${p.page}">Open full page →</a></article>`).join("");
+    }
+
+    loadTopPicks().catch(() => {
+      document.getElementById("top-picks-status").textContent = "We couldn't load top picks right now. Please refresh in a moment.";
+      document.getElementById("home-refresh-time").textContent = "Unavailable (last fetch failed)";
+    });
+  </script>
+
 </body>
 </html>

--- a/lucky-dip.html
+++ b/lucky-dip.html
@@ -374,7 +374,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip" class="active">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -414,10 +413,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" class="active" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>

--- a/lucky-dip2.html
+++ b/lucky-dip2.html
@@ -181,7 +181,6 @@
     <a href="/index">HOME</a>
     <a href="/hda-value">MATCH RESULT</a>
     <a href="/uo-value">UNDER/OVER 2.5</a>
-    <a href="/lucky-dip" class="active">LUCKY DIP</a>
     <a href="/historical">HISTORICAL DATA</a>
   </nav>
 

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -350,6 +350,23 @@
       color: #8c8c8e;
     }
 
+
+    .proof-strip {
+      margin: 6px 0 12px;
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(24, 24, 26, 0.96);
+      border: 1px solid rgba(255,255,255,0.08);
+      display: grid;
+      gap: 8px;
+    }
+    .proof-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: #f7b057; }
+    .proof-items { margin: 0; padding-left: 18px; display: grid; gap: 4px; font-size: 12px; color: #d9d9d9; }
+    .proof-items a { color: #f7b057; }
+    .freshness-inline { margin-top: 6px; font-size: 12px; color: #cfcfcf; }
+    .cadence-row { display:flex; flex-wrap:wrap; gap:8px; }
+    .cadence-chip { font-size:11px; border:1px solid rgba(240,147,0,.45); padding:4px 8px; border-radius:999px; color:#e8c08c; }
+
     /* Footer */
     .home-footer {
       margin-top: 18px;
@@ -601,7 +618,7 @@
     <p class="loading-subtitle">
       We&#39;re surfacing fixtures where the model strongly favours under or over 2.5 goals.
     </p>
-    <div class="loading-ticker">Loading match data...</div>
+    <div class="loading-ticker">Fetching latest sheet data...</div>
   </div>
 
   <div class="home-page">
@@ -629,7 +646,6 @@
         <a href="/index">Home</a>
         <a href="/hda-highchance">Match Result</a>
         <a href="/uo-highchance" class="active">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -640,6 +656,18 @@
         <a href="/uo-highchance" class="active">Highest Chance</a>
       </div>
     </header>
+
+
+    <section class="proof-strip" aria-label="Trust and methodology notes">
+      <p class="proof-title">Before you use these picks</p>
+      <ul class="proof-items">
+        <li>Compare today's picks with <a href="/historical">Historical Data</a> and the <a href="/faqs">FAQ methodology</a>.</li>
+        <li>Data source: live model output and bookmaker prices from linked Google Sheets.</li>
+        <li>Value compares model chance vs market chance — it is not a guarantee on a single fixture.</li>
+      </ul>
+      <p class="freshness-inline">Last refreshed: <strong id="refresh-time">Loading…</strong> (page data refresh time).</p>
+      <div class="cadence-row"><span class="cadence-chip">Friday shortlist</span><span class="cadence-chip">Weekend picks</span><span class="cadence-chip">Monday review</span></div>
+    </section>
 
     <!-- Main data layout -->
     <section class="data-layout">
@@ -713,10 +741,6 @@
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
     </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
-    </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>
       <span class="label">History</span>
@@ -738,6 +762,12 @@
     function csvToRows(text) {
       return text.trim().split("\n").map(r => r.split(","));
     }
+
+    function formatRefreshTime(d){ return d.toLocaleString("en-GB", { day:"2-digit", month:"short", hour:"2-digit", minute:"2-digit", hour12:false, timeZone:"UTC" }) + " UTC"; }
+
+    function setRefreshNow(){ const el=document.getElementById("refresh-time"); if(el){ el.textContent=formatRefreshTime(new Date()); } }
+
+    function showLoadError(){ const container=document.getElementById("sheet-data"); if(container){ container.innerHTML="<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn\'t load the live data just now. Please refresh in a minute.</p>"; } }
 
     function hideLoadingOverlay() {
       const overlay = document.getElementById("loadingOverlay");
@@ -766,12 +796,10 @@
         buildDayButtons();
         attachResultButtonHandlers();
         renderTable();
+        setRefreshNow();
       } catch (err) {
         console.error("Error loading CSV:", err);
-        const container = document.getElementById("sheet-data");
-        if (container) {
-          container.innerHTML = "<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn&#39;t load today&#39;s data. Please refresh the page in a moment.</p>";
-        }
+        showLoadError();
       } finally {
         hideLoadingOverlay();
       }

--- a/uo-histd.html
+++ b/uo-histd.html
@@ -643,7 +643,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -762,10 +761,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/uo-histf.html
+++ b/uo-histf.html
@@ -643,7 +643,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -761,10 +760,6 @@
     <a href="/uo-value" data-key="uo">
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
-    </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
     </a>
     <a href="/historical" class="active" data-key="historical">
       <span class="icon">📊</span>

--- a/uo-results.html
+++ b/uo-results.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>MC PREDICT - MATCH RESULT BEST VALUE</title>
+  <title>MC PREDICT - UNDER/OVER 2.5 BEST VALUE (Historical)</title>
 
   <!-- Fonts + site stylesheet -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -270,7 +270,7 @@
         </div>
         <div class="topbar-tag">
           <span class="topbar-tag-dot"></span>
-          <span>Historical · Match Result</span>
+          <span>Historical · Under/Over 2.5</span>
         </div>
       </div>
 
@@ -279,7 +279,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical" class="active">Historical</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -290,7 +289,7 @@
     <section>
       <div class="results-header">
         <div class="results-eyebrow">Historical Summary</div>
-        <h2 class="results-title">Match Result – Best Value</h2>
+        <h2 class="results-title">Under/Over 2.5 – Best Value</h2>
         <p class="results-subtitle">
           A breakdown of how the best-value categories have performed across multiple seasons.
         </p>

--- a/uo-value.html
+++ b/uo-value.html
@@ -350,6 +350,23 @@
       color: #8c8c8e;
     }
 
+
+    .proof-strip {
+      margin: 6px 0 12px;
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(24, 24, 26, 0.96);
+      border: 1px solid rgba(255,255,255,0.08);
+      display: grid;
+      gap: 8px;
+    }
+    .proof-title { margin: 0; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; color: #f7b057; }
+    .proof-items { margin: 0; padding-left: 18px; display: grid; gap: 4px; font-size: 12px; color: #d9d9d9; }
+    .proof-items a { color: #f7b057; }
+    .freshness-inline { margin-top: 6px; font-size: 12px; color: #cfcfcf; }
+    .cadence-row { display:flex; flex-wrap:wrap; gap:8px; }
+    .cadence-chip { font-size:11px; border:1px solid rgba(240,147,0,.45); padding:4px 8px; border-radius:999px; color:#e8c08c; }
+
     /* Footer */
     .home-footer {
       margin-top: 18px;
@@ -601,7 +618,7 @@
     <p class="loading-subtitle">
       We&#39;re checking where the model and the market disagree most on the 2.5 goals line.
     </p>
-    <div class="loading-ticker">Loading match data...</div>
+    <div class="loading-ticker">Fetching latest sheet data...</div>
   </div>
 
   <div class="home-page">
@@ -629,7 +646,6 @@
         <a href="/index">Home</a>
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value" class="active">Under/Over 2.5</a>
-        <a href="/lucky-dip">Lucky Dip</a>
         <a href="/historical">Historical Data</a>
         <a href="/faqs">FAQs</a>
       </nav>
@@ -640,6 +656,18 @@
         <a href="/uo-highchance">Highest Chance</a>
       </div>
     </header>
+
+
+    <section class="proof-strip" aria-label="Trust and methodology notes">
+      <p class="proof-title">Before you use these picks</p>
+      <ul class="proof-items">
+        <li>Compare today's picks with <a href="/historical">Historical Data</a> and the <a href="/faqs">FAQ methodology</a>.</li>
+        <li>Data source: live model output and bookmaker prices from linked Google Sheets.</li>
+        <li>Value compares model chance vs market chance — it is not a guarantee on a single fixture.</li>
+      </ul>
+      <p class="freshness-inline">Last refreshed: <strong id="refresh-time">Loading…</strong> (page data refresh time).</p>
+      <div class="cadence-row"><span class="cadence-chip">Friday shortlist</span><span class="cadence-chip">Weekend picks</span><span class="cadence-chip">Monday review</span></div>
+    </section>
 
     <!-- Main data layout -->
     <section class="data-layout">
@@ -715,10 +743,6 @@
       <span class="icon">⚽</span>
       <span class="label">U/O 2.5</span>
     </a>
-    <a href="/lucky-dip" data-key="lucky">
-      <span class="icon">🎲</span>
-      <span class="label">Lucky</span>
-    </a>
     <a href="/historical" data-key="historical">
       <span class="icon">📊</span>
       <span class="label">History</span>
@@ -740,6 +764,12 @@
     function csvToRows(text) {
       return text.trim().split("\n").map(r => r.split(","));
     }
+
+    function formatRefreshTime(d){ return d.toLocaleString("en-GB", { day:"2-digit", month:"short", hour:"2-digit", minute:"2-digit", hour12:false, timeZone:"UTC" }) + " UTC"; }
+
+    function setRefreshNow(){ const el=document.getElementById("refresh-time"); if(el){ el.textContent=formatRefreshTime(new Date()); } }
+
+    function showLoadError(){ const container=document.getElementById("sheet-data"); if(container){ container.innerHTML="<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn\'t load the live data just now. Please refresh in a minute.</p>"; } }
 
     function hideLoadingOverlay() {
       const overlay = document.getElementById("loadingOverlay");
@@ -768,12 +798,10 @@
         buildDayButtons();
         attachResultButtonHandlers();
         renderTable();
+        setRefreshNow();
       } catch (err) {
         console.error("Error loading CSV:", err);
-        const container = document.getElementById("sheet-data");
-        if (container) {
-          container.innerHTML = "<p style='font-size:13px;color:#f7b057;margin:8px 0;'>We couldn&#39;t load today&#39;s data. Please refresh the page in a moment.</p>";
-        }
+        showLoadError();
       } finally {
         hideLoadingOverlay();
       }


### PR DESCRIPTION
### Motivation

- Clean up navigation by removing an unfinished `Lucky Dip` feature and surface trust/freshness information for live feeds. 
- Improve user clarity by updating page titles and loading copy to reflect the redesign and data sources.
- Provide a lightweight client-side aggregator to surface top picks from multiple CSV feeds and display a refresh timestamp.

### Description

- Removed `Lucky Dip` links from the primary and bottom navigation across pages (`index.html`, `historical.html`, `hda-*`, `uo-*`, `faqs.html`, `lucky-dip*.html`, etc.).
- Added a reusable trust/freshness UI (`.proof-strip`, `.freshness-strip`, chips) and injected markup on live pages (`hda-value`, `hda-highchance`, `uo-value`, `uo-highchance`, `index.html`) to show methodology notes and a `Last refreshed` timestamp element (`#refresh-time`, `#home-refresh-time`).
- Replaced several loading lines with clearer copy (`Loading match data...` -> `Fetching latest sheet data...`) and updated page titles/headings to use `Match Result`/`Under/Over 2.5` and explicit fractional/decimal labels where applicable.
- Added small client-side helpers and error handling: `formatRefreshTime`, `setRefreshNow`, and `showLoadError` are invoked after CSV fetches; several pages now call `setRefreshNow()` on successful CSV load and use `showLoadError()` on failure.
- Implemented a homepage `Top Picks` aggregator script (`parseCSVLine`, `parseCSV`, `mapHeaders`, `loadFeed`, `loadTopPicks`) that fetches two public CSV feeds, ranks picks by a simple `score` heuristic, and renders top cards into `#top-picks-grid` with graceful handling of partial or total feed failures.

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3acd87db8832fb98a7ff536d3293b)