### PR TITLE
Add Grand National Picker page with client-side CSV filters and nav link

### DIFF
--- a/Test.html
+++ b/Test.html
@@ -733,6 +733,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
     </header>

--- a/Test2.html
+++ b/Test2.html
@@ -644,6 +644,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/grand-national-picker.css
+++ b/grand-national-picker.css
@@ -1,0 +1,143 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+.gn-page {
+  min-height: 100vh;
+  font-family: 'Proxima Nova', Arial, sans-serif;
+  color: #d3d3d3;
+  background: radial-gradient(circle at top left, #3c3c3e 0, #2c2c2e 40%, #18181a 100%);
+}
+
+.gn-shell {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 14px 14px 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.gn-page .home-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding-bottom: 8px;
+}
+
+.gn-page .topbar-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #3a3a3c, #262628);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.45);
+}
+
+.gn-page .topbar-left { display: flex; align-items: center; gap: 10px; }
+.gn-page .topbar-logo {
+  width: 44px; height: 44px; border-radius: 14px; overflow: hidden;
+  background: radial-gradient(circle at 30% 20%, #f09300, #1d1d1f);
+  display: flex; align-items: center; justify-content: center;
+}
+.gn-page .topbar-logo img { width: 70%; height: 70%; object-fit: contain; }
+.gn-page .topbar-title h1 { margin: 0; font-size: 20px; letter-spacing: 0.18em; color: #fff; }
+.gn-page .topbar-title span { font-size: 12px; color: #a5a5a7; }
+.gn-page .topbar-tag {
+  display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border-radius: 999px;
+  background: rgba(240,147,0,0.1); color: #f7b057; font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
+}
+.gn-page .topbar-tag-dot { width: 7px; height: 7px; border-radius: 50%; background: #40c456; box-shadow: 0 0 0 6px rgba(64,196,86,.18); }
+
+.gn-page .primary-nav { display: none; gap: 10px; margin-top: 20px; flex-wrap: wrap; }
+.gn-page .primary-nav a {
+  padding: 8px 16px; border-radius: 999px; background: rgba(31,31,33,.86);
+  border: 1px solid rgba(255,255,255,.08); text-decoration: none; color: #e0e0e0;
+  letter-spacing: .08em; font-size: 14px; text-transform: uppercase;
+}
+.gn-page .primary-nav a.active {
+  background: linear-gradient(135deg, #f09300, #e8a94a);
+  color: #111;
+  border-color: rgba(255,255,255,.18);
+}
+
+.gn-title-panel {
+  background: radial-gradient(circle at right top, rgba(240,147,0,.2), rgba(24,24,26,.95));
+  border: 1px solid rgba(255,255,255,.06);
+  border-radius: 20px;
+  padding: 18px;
+}
+.gn-eyebrow { margin: 0 0 8px; font-size: 12px; color: #f7b057; text-transform: uppercase; letter-spacing: .14em; }
+.gn-title-panel h2 { margin: 0 0 10px; color: #fff; font-size: 28px; }
+.gn-title-panel p { margin: 0; color: #c3c3c5; font-size: 14px; line-height: 1.5; }
+
+.gn-layout { display: grid; grid-template-columns: 1fr; gap: 16px; }
+.gn-filters, .gn-results {
+  background: rgba(24,24,26,.96);
+  border: 1px solid rgba(255,255,255,.06);
+  border-radius: 18px;
+  padding: 16px;
+}
+.gn-filters h3, .gn-results h3 { margin: 0 0 14px; color: #fff; font-size: 18px; }
+
+.gn-filter-item { margin-bottom: 16px; }
+.gn-filter-head { display: flex; justify-content: space-between; gap: 8px; margin-bottom: 8px; font-size: 14px; }
+.gn-filter-head strong { color: #ececee; font-weight: 700; }
+.gn-filter-head span { color: #f7b057; white-space: nowrap; }
+
+.gn-range {
+  width: 100%;
+  accent-color: #f09300;
+}
+
+.gn-results-head { display: flex; justify-content: space-between; gap: 10px; align-items: center; margin-bottom: 10px; }
+#gn-match-count { font-size: 13px; color: #f7b057; }
+.gn-loading, .gn-error {
+  padding: 10px 12px; border-radius: 10px; font-size: 13px; margin-top: 6px;
+}
+.gn-loading { background: rgba(255,255,255,.03); border-left: 3px solid #f09300; }
+.gn-error { background: rgba(161,47,47,.2); border-left: 3px solid #df5757; color: #ffd7d7; }
+
+.gn-table-wrap { overflow-x: auto; }
+.gn-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.gn-table th, .gn-table td { padding: 10px 9px; border-bottom: 1px solid rgba(255,255,255,.06); text-align: left; }
+.gn-table th { color: #f7b057; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+.gn-table td { color: #e4e4e6; }
+
+.gn-cards { display: grid; grid-template-columns: 1fr; gap: 12px; }
+.gn-card {
+  border: 1px solid rgba(255,255,255,.08);
+  background: linear-gradient(135deg, rgba(36,36,38,.92), rgba(21,21,23,.94));
+  border-radius: 14px;
+  padding: 12px;
+}
+.gn-card h4 { margin: 0 0 8px; color: #fff; font-size: 17px; }
+.gn-card-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 10px;
+  font-size: 13px;
+}
+.gn-card-grid span { color: #a8a8aa; }
+.gn-card-grid strong { color: #ececee; font-weight: 600; }
+
+@media (min-width: 900px) {
+  .gn-page .primary-nav { display: flex; }
+  .gn-layout {
+    grid-template-columns: minmax(280px, 330px) 1fr;
+    align-items: start;
+  }
+  .gn-filters { position: sticky; top: 106px; }
+  .gn-cards { display: none !important; }
+  .gn-table-wrap { display: block !important; }
+}
+
+@media (max-width: 899px) {
+  .gn-table-wrap { display: none !important; }
+  .gn-cards { display: grid !important; }
+}

--- a/grand-national-picker.html
+++ b/grand-national-picker.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MC PREDICT - Grand National Picker</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="grand-national-picker.css">
+</head>
+<body class="home gn-page">
+  <div class="home-page gn-shell">
+    <header class="home-topbar">
+      <div class="topbar-inner">
+        <div class="topbar-left">
+          <div class="topbar-logo">
+            <img src="images/mcpredcirclebg.png" alt="MC Predict Logo">
+          </div>
+          <div class="topbar-title">
+            <h1>MC PREDICT</h1>
+            <span>Data-driven Football predictions</span>
+          </div>
+        </div>
+        <div class="topbar-tag">
+          <span class="topbar-tag-dot"></span>
+          <span>Special feature</span>
+        </div>
+      </div>
+
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="/index">Home</a>
+        <a href="/hda-value">Match Result</a>
+        <a href="/uo-value">Under/Over 2.5</a>
+        <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html" class="active">Grand National Picker</a>
+        <a href="/faqs">FAQs</a>
+      </nav>
+    </header>
+
+    <main class="gn-main">
+      <section class="gn-title-panel">
+        <p class="gn-eyebrow">Temporary race week tool</p>
+        <h2>Grand National Picker</h2>
+        <p>Adjust the sliders to find runners that fit your preferred profile. At least one horse will always remain visible.</p>
+      </section>
+
+      <section class="gn-layout">
+        <aside class="gn-filters" aria-label="Filter controls">
+          <h3>Filters</h3>
+          <div id="gn-filter-list"></div>
+        </aside>
+
+        <section class="gn-results" aria-live="polite">
+          <div class="gn-results-head">
+            <h3>Matching Runners</h3>
+            <span id="gn-match-count">Loading…</span>
+          </div>
+
+          <div id="gn-loading" class="gn-loading">Loading runner data…</div>
+          <div id="gn-error" class="gn-error" hidden></div>
+
+          <div id="gn-table-wrap" class="gn-table-wrap" hidden>
+            <table class="gn-table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Age</th>
+                  <th>Weight</th>
+                  <th>Horse Rating</th>
+                  <th>Timeform Rating</th>
+                  <th>Jumping Rating</th>
+                  <th>Odds</th>
+                </tr>
+              </thead>
+              <tbody id="gn-table-body"></tbody>
+            </table>
+          </div>
+
+          <div id="gn-cards" class="gn-cards" hidden></div>
+        </section>
+      </section>
+    </main>
+  </div>
+
+  <script src="grand-national-picker.js"></script>
+</body>
+</html>

--- a/grand-national-picker.js
+++ b/grand-national-picker.js
@@ -1,0 +1,348 @@
+(() => {
+  const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQylUta79Sg4Vio7K0j8zDe_6I3GOVJANv6RVj5u_uODW6fEk-tasXLciOG-20t1a3Qx7U_5PoSyDq7/pub?gid=0&single=true&output=csv';
+
+  const filterDefs = {
+    horse: { label: 'Horse Rating', step: 1 },
+    timeform: { label: 'Timeform Rating', step: 1 },
+    jumping: { label: 'Jumping Rating', step: 0.1 },
+    weight: { label: 'Weight Carried', step: 1 },
+    odds: { label: 'Odds', step: 1 }
+  };
+
+  const relaxOrder = ['odds', 'weight', 'jumping', 'timeform', 'horse'];
+  let dataset = [];
+  let bounds = {};
+  let filters = {};
+  let oddsScale = [];
+
+  const el = {
+    filterList: document.getElementById('gn-filter-list'),
+    tableBody: document.getElementById('gn-table-body'),
+    cards: document.getElementById('gn-cards'),
+    matchCount: document.getElementById('gn-match-count'),
+    loading: document.getElementById('gn-loading'),
+    error: document.getElementById('gn-error'),
+    tableWrap: document.getElementById('gn-table-wrap')
+  };
+
+  function parseCSV(text) {
+    const rows = [];
+    let row = [];
+    let cur = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < text.length; i += 1) {
+      const char = text[i];
+      const next = text[i + 1];
+
+      if (char === '"') {
+        if (inQuotes && next === '"') {
+          cur += '"';
+          i += 1;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char === ',' && !inQuotes) {
+        row.push(cur);
+        cur = '';
+      } else if ((char === '\n' || char === '\r') && !inQuotes) {
+        if (char === '\r' && next === '\n') i += 1;
+        row.push(cur);
+        if (row.some((cell) => String(cell).trim() !== '')) rows.push(row);
+        row = [];
+        cur = '';
+      } else {
+        cur += char;
+      }
+    }
+
+    if (cur.length || row.length) {
+      row.push(cur);
+      if (row.some((cell) => String(cell).trim() !== '')) rows.push(row);
+    }
+
+    if (!rows.length) return [];
+    const headers = rows[0].map((h) => h.trim());
+    return rows.slice(1).map((r) => {
+      const out = {};
+      headers.forEach((h, idx) => {
+        out[h] = (r[idx] || '').trim();
+      });
+      return out;
+    });
+  }
+
+  function parseNumber(value) {
+    const cleaned = String(value || '').trim();
+    if (!cleaned) return null;
+    const num = Number(cleaned.replace(/[^0-9.+-]/g, ''));
+    return Number.isFinite(num) ? num : null;
+  }
+
+  function parseWeightToPounds(weight) {
+    const text = String(weight || '').trim();
+    const m = text.match(/^(\d+)\s*[-:]\s*(\d+)$/);
+    if (!m) return null;
+    const stones = Number(m[1]);
+    const pounds = Number(m[2]);
+    if (!Number.isFinite(stones) || !Number.isFinite(pounds)) return null;
+    return (stones * 14) + pounds;
+  }
+
+  function poundsToWeightString(totalPounds) {
+    const stones = Math.floor(totalPounds / 14);
+    const pounds = totalPounds % 14;
+    return `${stones}-${pounds}`;
+  }
+
+  function parseFractionalOdds(oddsText) {
+    const text = String(oddsText || '').trim();
+    const m = text.match(/^(\d+)\s*\/\s*(\d+)$/);
+    if (!m) return null;
+    const num = Number(m[1]);
+    const den = Number(m[2]);
+    if (!Number.isFinite(num) || !Number.isFinite(den) || den === 0) return null;
+    return num / den;
+  }
+
+  function isNonRunner(row) {
+    const combined = `${row['Name'] || ''} ${row['Timeform write up'] || ''} ${row['Fractional Odds'] || ''}`;
+    return /\bNR\b|non[-\s]?runner/i.test(combined);
+  }
+
+  function normalizeData(rows) {
+    return rows
+      .filter((r) => !isNonRunner(r))
+      .map((r) => {
+        const horseRating = parseNumber(r['Overall Rating']);
+        const timeformRating = parseNumber(r['Timeform Rating']);
+        const jumpIndex = parseNumber(r['Jump Index']);
+        const weightPounds = parseWeightToPounds(r['Weight']);
+        const oddsValue = parseFractionalOdds(r['Fractional Odds']);
+
+        if (!r['Name'] || horseRating == null || timeformRating == null || jumpIndex == null || weightPounds == null || oddsValue == null) {
+          return null;
+        }
+
+        return {
+          name: r['Name'],
+          age: r['Age'] || '—',
+          weight: r['Weight'],
+          horseRating,
+          timeformRating,
+          jumpingRating: jumpIndex,
+          odds: r['Fractional Odds'],
+          oddsValue,
+          weightPounds
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function setupBounds() {
+    const vals = {
+      horse: dataset.map((d) => d.horseRating),
+      timeform: dataset.map((d) => d.timeformRating),
+      jumping: dataset.map((d) => d.jumpingRating),
+      weight: dataset.map((d) => d.weightPounds),
+      odds: dataset.map((d) => d.oddsValue)
+    };
+
+    oddsScale = [...new Set(vals.odds)].sort((a, b) => a - b);
+
+    bounds = {
+      horse: { min: Math.min(...vals.horse), max: Math.max(...vals.horse) },
+      timeform: { min: Math.min(...vals.timeform), max: Math.max(...vals.timeform) },
+      jumping: { min: Math.min(...vals.jumping), max: Math.max(...vals.jumping) },
+      weight: { min: Math.min(...vals.weight), max: Math.max(...vals.weight) },
+      odds: { minIndex: 0, maxIndex: Math.max(0, oddsScale.length - 1) }
+    };
+
+    filters = {
+      horse: bounds.horse.min,
+      timeform: bounds.timeform.min,
+      jumping: Number(bounds.jumping.min.toFixed(1)),
+      weight: bounds.weight.max,
+      odds: bounds.odds.minIndex
+    };
+  }
+
+  function formatLabel(key, value) {
+    if (key === 'horse') return `${value}+`;
+    if (key === 'timeform') return `${value}+`;
+    if (key === 'jumping') return `${Number(value).toFixed(1)}+`;
+    if (key === 'weight') return `${poundsToWeightString(Number(value))} or less`;
+    if (key === 'odds') {
+      const oddVal = oddsScale[value];
+      const runner = dataset.find((d) => d.oddsValue === oddVal);
+      return `${runner ? runner.odds : `${oddVal}/1`}+`;
+    }
+    return String(value);
+  }
+
+  function buildFilterUI() {
+    el.filterList.innerHTML = '';
+
+    Object.keys(filterDefs).forEach((key) => {
+      const item = document.createElement('div');
+      item.className = 'gn-filter-item';
+
+      const head = document.createElement('div');
+      head.className = 'gn-filter-head';
+      head.innerHTML = `<strong>${filterDefs[key].label}</strong><span id="gn-label-${key}"></span>`;
+
+      const input = document.createElement('input');
+      input.className = 'gn-range';
+      input.type = 'range';
+      input.id = `gn-slider-${key}`;
+
+      if (key === 'horse' || key === 'timeform') {
+        input.min = String(Math.floor(bounds[key].min));
+        input.max = String(Math.ceil(bounds[key].max));
+        input.step = '1';
+        input.value = String(filters[key]);
+      } else if (key === 'jumping') {
+        input.min = String(Math.floor(bounds.jumping.min * 10) / 10);
+        input.max = String(Math.ceil(bounds.jumping.max * 10) / 10);
+        input.step = '0.1';
+        input.value = String(filters.jumping);
+      } else if (key === 'weight') {
+        input.min = String(Math.floor(bounds.weight.min));
+        input.max = String(Math.ceil(bounds.weight.max));
+        input.step = '1';
+        input.value = String(filters.weight);
+      } else if (key === 'odds') {
+        input.min = String(bounds.odds.minIndex);
+        input.max = String(bounds.odds.maxIndex);
+        input.step = '1';
+        input.value = String(filters.odds);
+      }
+
+      input.addEventListener('input', () => {
+        filters[key] = key === 'jumping' ? Number(input.value) : Number(input.value);
+        enforceOneResult(key);
+        syncSliders();
+        render();
+      });
+
+      item.append(head, input);
+      el.filterList.appendChild(item);
+    });
+
+    syncSliders();
+  }
+
+  function getMatches(currentFilters) {
+    const oddThreshold = oddsScale[currentFilters.odds];
+    return dataset
+      .filter((d) => d.horseRating >= currentFilters.horse)
+      .filter((d) => d.timeformRating >= currentFilters.timeform)
+      .filter((d) => d.jumpingRating >= currentFilters.jumping)
+      .filter((d) => d.weightPounds <= currentFilters.weight)
+      .filter((d) => d.oddsValue >= oddThreshold)
+      .sort((a, b) => a.oddsValue - b.oddsValue || b.horseRating - a.horseRating);
+  }
+
+  function nextLessRestrictiveValue(key, value) {
+    if (key === 'horse' || key === 'timeform') return Math.max(bounds[key].min, value - 1);
+    if (key === 'jumping') return Number(Math.max(bounds.jumping.min, (value - 0.1)).toFixed(1));
+    if (key === 'weight') return Math.min(bounds.weight.max, value + 1);
+    if (key === 'odds') return Math.max(bounds.odds.minIndex, value - 1);
+    return value;
+  }
+
+  function canRelax(key, value) {
+    if (key === 'horse' || key === 'timeform') return value > bounds[key].min;
+    if (key === 'jumping') return value > bounds.jumping.min;
+    if (key === 'weight') return value < bounds.weight.max;
+    if (key === 'odds') return value > bounds.odds.minIndex;
+    return false;
+  }
+
+  function enforceOneResult(changedKey) {
+    if (getMatches(filters).length > 0) return;
+
+    for (const key of relaxOrder) {
+      if (key === changedKey) continue;
+      while (canRelax(key, filters[key])) {
+        const next = nextLessRestrictiveValue(key, filters[key]);
+        if (next === filters[key]) break;
+        filters[key] = next;
+        if (getMatches(filters).length > 0) return;
+      }
+    }
+
+    while (canRelax(changedKey, filters[changedKey])) {
+      const next = nextLessRestrictiveValue(changedKey, filters[changedKey]);
+      if (next === filters[changedKey]) break;
+      filters[changedKey] = next;
+      if (getMatches(filters).length > 0) return;
+    }
+  }
+
+  function syncSliders() {
+    Object.keys(filterDefs).forEach((key) => {
+      const slider = document.getElementById(`gn-slider-${key}`);
+      const label = document.getElementById(`gn-label-${key}`);
+      if (slider) slider.value = String(filters[key]);
+      if (label) label.textContent = formatLabel(key, filters[key]);
+    });
+  }
+
+  function render() {
+    const matches = getMatches(filters);
+    el.matchCount.textContent = `${matches.length} runner${matches.length === 1 ? '' : 's'} shown`;
+
+    el.tableBody.innerHTML = matches.map((m) => `
+      <tr>
+        <td>${m.name}</td>
+        <td>${m.age}</td>
+        <td>${m.weight}</td>
+        <td>${m.horseRating}</td>
+        <td>${m.timeformRating}</td>
+        <td>${m.jumpingRating.toFixed(1)}</td>
+        <td>${m.odds}</td>
+      </tr>
+    `).join('');
+
+    el.cards.innerHTML = matches.map((m) => `
+      <article class="gn-card">
+        <h4>${m.name}</h4>
+        <div class="gn-card-grid">
+          <span>Age</span><strong>${m.age}</strong>
+          <span>Weight</span><strong>${m.weight}</strong>
+          <span>Horse Rating</span><strong>${m.horseRating}</strong>
+          <span>Timeform Rating</span><strong>${m.timeformRating}</strong>
+          <span>Jumping Rating</span><strong>${m.jumpingRating.toFixed(1)}</strong>
+          <span>Odds</span><strong>${m.odds}</strong>
+        </div>
+      </article>
+    `).join('');
+
+    el.tableWrap.hidden = false;
+    el.cards.hidden = false;
+  }
+
+  async function init() {
+    try {
+      const res = await fetch(CSV_URL, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Unable to fetch CSV (${res.status})`);
+      const csvText = await res.text();
+      const rows = parseCSV(csvText);
+      dataset = normalizeData(rows);
+      if (!dataset.length) throw new Error('No valid runners found in CSV.');
+
+      setupBounds();
+      buildFilterUI();
+      render();
+      el.loading.hidden = true;
+    } catch (err) {
+      el.loading.hidden = true;
+      el.error.hidden = false;
+      el.error.textContent = `Could not load Grand National data: ${err.message}`;
+      el.matchCount.textContent = 'No data';
+    }
+  }
+
+  init();
+})();

--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -627,6 +627,7 @@
         <a href="/hda-highchance" class="active">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/hda-histd.html
+++ b/hda-histd.html
@@ -644,6 +644,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/hda-histf.html
+++ b/hda-histf.html
@@ -645,6 +645,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/hda-results.html
+++ b/hda-results.html
@@ -465,6 +465,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
     </header>

--- a/hda-value.html
+++ b/hda-value.html
@@ -618,6 +618,7 @@
         <a href="/hda-value" class="active">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/historical.html
+++ b/historical.html
@@ -394,6 +394,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
     </header>

--- a/index.html
+++ b/index.html
@@ -676,6 +676,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
     </header>

--- a/lucky-dip.html
+++ b/lucky-dip.html
@@ -375,6 +375,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
     </header>

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -647,6 +647,7 @@
         <a href="/hda-highchance">Match Result</a>
         <a href="/uo-highchance" class="active">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/uo-histd.html
+++ b/uo-histd.html
@@ -644,6 +644,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/uo-histf.html
+++ b/uo-histf.html
@@ -644,6 +644,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value">Under/Over 2.5</a>
         <a href="/historical" class="active">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 

--- a/uo-value.html
+++ b/uo-value.html
@@ -647,6 +647,7 @@
         <a href="/hda-value">Match Result</a>
         <a href="/uo-value" class="active">Under/Over 2.5</a>
         <a href="/historical">Historical Data</a>
+        <a href="/grand-national-picker.html">Grand National Picker</a>
         <a href="/faqs">FAQs</a>
       </nav>
 


### PR DESCRIPTION
### Motivation
- Provide a temporary, standalone "Grand National Picker" race-week feature that matches the existing MCPredict visual style while keeping page-specific CSS/JS isolated.
- Allow users to filter runners from a published Google Sheets CSV using five sliders (Horse Rating, Timeform Rating, Jumping, Weight, Odds) with robust parsing for racing weights and fractional odds. 
- Ensure UX guarantees (at least one runner visible) by auto-relaxing filters in a deterministic priority order when filters would otherwise empty results.

### Description
- Added a new standalone page `grand-national-picker.html` that reuses the site header/nav styling and includes a title panel, helper note, a filter sidebar with five sliders, and a responsive results area (desktop table + mobile cards). 
- Added page-scoped assets `grand-national-picker.css` (styling and responsive layout) and `grand-national-picker.js` (client-side CSV fetch, CSV parsing, filter/slider UI, parsing helpers, filtering/sorting and auto-relax logic). 
- Implemented robust data handling in `grand-national-picker.js`: safe CSV parsing, non-runner detection, conversion helpers `parseWeightToPounds` and `parseFractionalOdds`, numeric normalization, runtime-derived slider bounds, live filtering, and sort by shortest numeric odds. 
- Implemented deterministic auto-relax logic to maintain at least one visible horse, relaxing filters in this priority order: `odds`, `weight`, `jumping`, `timeform`, `horse`, and reflecting any auto-relaxed values back to slider handles and labels immediately. 
- Added a temporary navigation link `Grand National Picker` (`/grand-national-picker.html`) to existing primary nav blocks across the site so the new page is reachable without changing existing nav styles or behaviour.
- Files created: `grand-national-picker.html`, `grand-national-picker.css`, `grand-national-picker.js`; multiple existing HTML pages were updated to include the nav link. 

### Testing
- Ran static JS check with `node --check grand-national-picker.js` and it passed. 
- Performed local JavaScript smoke tests verifying weight parsing (`11-12` → `166` pounds), fractional odds parsing (`17/2` → `8.5`), odds-based filtering and shortest-odds-first sorting, and the auto-relax behaviour; smoke tests passed. 
- Attempted network CSV fetch validation from the container using Python, but the environment blocked outbound fetch with a proxy/tunnel `403 Forbidden`, so live fetch was not validated in-container; client-side fetch code handles fetch failures and surfaces an error message in the UI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8dc960264832fb8fbe4d274f9964b)