### PR TITLE
Grand National: white table header and homepage CTA

### DIFF
--- a/grand-national-picker.css
+++ b/grand-national-picker.css
@@ -106,7 +106,7 @@ html, body {
 .gn-table-wrap { overflow-x: auto; }
 .gn-table { width: 100%; border-collapse: collapse; font-size: 14px; }
 .gn-table th, .gn-table td { padding: 10px 9px; border-bottom: 1px solid rgba(255,255,255,.06); text-align: left; }
-.gn-table th { color: #f7b057; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+.gn-table th { color: #ffffff; font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
 .gn-table td { color: #e4e4e6; }
 
 .gn-cards { display: grid; grid-template-columns: 1fr; gap: 12px; }

--- a/index.html
+++ b/index.html
@@ -721,6 +721,12 @@
               <span>Read the FAQs</span>
             </a>
           </div>
+          <div class="btn-pill-column">
+            <div class="btn-pill-label">Special feature</div>
+            <a href="/grand-national-picker.html" class="btn btn-ghost">
+              <span>Grand National Picker</span>
+            </a>
+          </div>
         </div>
 
         <div class="hero-meta-row">


### PR DESCRIPTION
### Motivation
- Improve contrast/readability of the Grand National Picker table header and provide quick access to the picker from the homepage CTA area while keeping the change minimal and scoped.

### Description
- Set `.gn-table th` color to `#ffffff` in `grand-national-picker.css` to make the table header text pure white without altering header background, spacing, or body row colors.
- Added a matching CTA in `index.html` inside the existing `.btn-pill-group` that reuses `btn btn-ghost` styling and links to `/grand-national-picker.html` to match height, radius, typography, spacing and hover behaviour.
- Changes are limited to `grand-national-picker.css` and `index.html` and do not modify JavaScript or other layout styles.

### Testing
- Ran `git diff -- grand-national-picker.css index.html` to confirm only the intended edits were made and the new selector and markup appear as expected.
- Ran `git status --short` and executed `git commit -m "Update GN table header color and add homepage CTA link"` to record the changes, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e00eca30832f9557e1b21fa6fcaa)