### PR TITLE
Move Grand National CTA into hero and add mobile bottom nav to picker page

### DIFF
--- a/grand-national-picker.css
+++ b/grand-national-picker.css
@@ -15,7 +15,7 @@ html, body {
   width: 100%;
   max-width: 1180px;
   margin: 0 auto;
-  padding: 14px 14px 36px;
+  padding: 14px 14px 70px;
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -126,8 +126,71 @@ html, body {
 .gn-card-grid span { color: #a8a8aa; }
 .gn-card-grid strong { color: #ececee; font-weight: 600; }
 
+.gn-page .bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  height: 58px;
+  padding: 6px 10px 8px;
+  background: linear-gradient(180deg, rgba(10, 10, 12, 0.1), #101012);
+  box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(16px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.gn-page .bottom-nav a {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+  border-radius: 999px;
+  padding: 4px 4px;
+  border: 1px solid transparent;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  font-size: 11px;
+  text-decoration: none;
+  color: #e0e0e0;
+  opacity: 0.8;
+  transition: background 0.2s ease, color 0.2s ease,
+              transform 0.12s ease, border-color 0.2s ease,
+              opacity 0.2s ease;
+}
+
+.gn-page .bottom-nav a .icon {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.gn-page .bottom-nav a .label {
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.gn-page .bottom-nav a:hover {
+  opacity: 1;
+  transform: translateY(-1px);
+}
+
+.gn-page .bottom-nav a.active {
+  background: radial-gradient(circle at top, #f09300, #a85e00);
+  color: #101010;
+  border-color: rgba(255, 255, 255, 0.15);
+  opacity: 1;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.75);
+}
+
 @media (min-width: 900px) {
   .gn-page .primary-nav { display: flex; }
+  .gn-page .bottom-nav { display: none; }
+  .gn-shell { padding-bottom: 36px; }
   .gn-layout {
     grid-template-columns: minmax(280px, 330px) 1fr;
     align-items: start;
@@ -140,4 +203,5 @@ html, body {
 @media (max-width: 899px) {
   .gn-table-wrap { display: none !important; }
   .gn-cards { display: grid !important; }
+  .gn-page .bottom-nav { display: flex; }
 }

--- a/grand-national-picker.html
+++ b/grand-national-picker.html
@@ -83,6 +83,29 @@
     </main>
   </div>
 
+  <nav class="bottom-nav" aria-label="Primary navigation">
+    <a href="/index" data-key="home">
+      <span class="icon">🏠</span>
+      <span class="label">Home</span>
+    </a>
+    <a href="/hda-value" data-key="hda">
+      <span class="icon">🏆</span>
+      <span class="label">Result</span>
+    </a>
+    <a href="/uo-value" data-key="uo">
+      <span class="icon">⚽</span>
+      <span class="label">U/O 2.5</span>
+    </a>
+    <a href="/historical" data-key="historical">
+      <span class="icon">📊</span>
+      <span class="label">History</span>
+    </a>
+    <a href="/faqs" data-key="faqs">
+      <span class="icon">❓</span>
+      <span class="label">FAQs</span>
+    </a>
+  </nav>
+
   <script src="grand-national-picker.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -700,6 +700,9 @@
           <a href="/uo-value" class="btn btn-outline">
             <span>Under/Over 2.5 Goals Predictions</span>
           </a>
+          <a href="/grand-national-picker.html" class="btn btn-outline">
+            <span>Grand National Picker</span>
+          </a>
         </div>
 
         <div class="btn-pill-group">
@@ -719,12 +722,6 @@
             <div class="btn-pill-label">New here?</div>
             <a href="/faqs" class="btn btn-ghost">
               <span>Read the FAQs</span>
-            </a>
-          </div>
-          <div class="btn-pill-column">
-            <div class="btn-pill-label">Special feature</div>
-            <a href="/grand-national-picker.html" class="btn btn-ghost">
-              <span>Grand National Picker</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Place the misplaced “Grand National Picker” CTA into the main hero CTA stack so it matches the large pill CTAs and remove the small duplicate from the lower utility row.
- Ensure the dedicated `/grand-national-picker.html` page uses the same mobile bottom navigation pattern as the rest of the site and avoid content overlap with the fixed nav.

### Description
- Added a new hero CTA anchor to `index.html` under the `Under/Over 2.5 Goals Predictions` button using the existing classes `btn btn-outline` so it inherits the large pill styling and behavior.
- Removed the small Grand National CTA from the lower pill/meta column in `index.html` while leaving the X/Twitter and `Read the FAQs` items unchanged.
- Inserted the standard bottom mobile nav markup into `grand-national-picker.html` to match the site navigation pattern.
- Added bottom-nav styles and responsive show/hide behavior to `grand-national-picker.css` and increased the page shell bottom padding to `padding: 14px 14px 70px;` to prevent the fixed nav overlapping content.
- Changed files: `index.html`, `grand-national-picker.html`, `grand-national-picker.css`.

### Testing
- Ran pattern checks with `rg` to confirm `Grand National Picker` occurrences and `bottom-nav` presence, which returned the expected updated locations and files successfully.
- Inspected the patch via `git diff -- index.html grand-national-picker.html grand-national-picker.css` and confirmed the HTML/CSS changes were limited to the three files and matched the requested modifications.
- Verified repository state with `git status --short` and created a commit; the commit succeeded and contains the scoped changes.
- No automated browser rendering tests were run in this environment (visual verification should be performed in a browser to confirm exact visual parity and responsiveness).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e689048c832fa4ba22015b7f0e78)