### PR TITLE
Make Grand National Picker use shared homepage mobile bottom nav

### DIFF
--- a/grand-national-picker.css
+++ b/grand-national-picker.css
@@ -21,51 +21,6 @@ html, body {
   gap: 18px;
 }
 
-.gn-page .home-topbar {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  padding-bottom: 8px;
-}
-
-.gn-page .topbar-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #3a3a3c, #262628);
-  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.45);
-}
-
-.gn-page .topbar-left { display: flex; align-items: center; gap: 10px; }
-.gn-page .topbar-logo {
-  width: 44px; height: 44px; border-radius: 14px; overflow: hidden;
-  background: radial-gradient(circle at 30% 20%, #f09300, #1d1d1f);
-  display: flex; align-items: center; justify-content: center;
-}
-.gn-page .topbar-logo img { width: 70%; height: 70%; object-fit: contain; }
-.gn-page .topbar-title h1 { margin: 0; font-size: 20px; letter-spacing: 0.18em; color: #fff; }
-.gn-page .topbar-title span { font-size: 12px; color: #a5a5a7; }
-.gn-page .topbar-tag {
-  display: inline-flex; align-items: center; gap: 6px; padding: 6px 10px; border-radius: 999px;
-  background: rgba(240,147,0,0.1); color: #f7b057; font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
-}
-.gn-page .topbar-tag-dot { width: 7px; height: 7px; border-radius: 50%; background: #40c456; box-shadow: 0 0 0 6px rgba(64,196,86,.18); }
-
-.gn-page .primary-nav { display: none; gap: 10px; margin-top: 20px; flex-wrap: wrap; }
-.gn-page .primary-nav a {
-  padding: 8px 16px; border-radius: 999px; background: rgba(31,31,33,.86);
-  border: 1px solid rgba(255,255,255,.08); text-decoration: none; color: #e0e0e0;
-  letter-spacing: .08em; font-size: 14px; text-transform: uppercase;
-}
-.gn-page .primary-nav a.active {
-  background: linear-gradient(135deg, #f09300, #e8a94a);
-  color: #111;
-  border-color: rgba(255,255,255,.18);
-}
-
 .gn-title-panel {
   background: radial-gradient(circle at right top, rgba(240,147,0,.2), rgba(24,24,26,.95));
   border: 1px solid rgba(255,255,255,.06);
@@ -126,71 +81,7 @@ html, body {
 .gn-card-grid span { color: #a8a8aa; }
 .gn-card-grid strong { color: #ececee; font-weight: 600; }
 
-.gn-page .bottom-nav {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 30;
-  height: 58px;
-  padding: 6px 10px 8px;
-  background: linear-gradient(180deg, rgba(10, 10, 12, 0.1), #101012);
-  box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.8);
-  backdrop-filter: blur(16px);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-}
-
-.gn-page .bottom-nav a {
-  flex: 1 1 0;
-  min-width: 0;
-  height: 100%;
-  border-radius: 999px;
-  padding: 4px 4px;
-  border: 1px solid transparent;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 2px;
-  font-size: 11px;
-  text-decoration: none;
-  color: #e0e0e0;
-  opacity: 0.8;
-  transition: background 0.2s ease, color 0.2s ease,
-              transform 0.12s ease, border-color 0.2s ease,
-              opacity 0.2s ease;
-}
-
-.gn-page .bottom-nav a .icon {
-  font-size: 16px;
-  line-height: 1;
-}
-
-.gn-page .bottom-nav a .label {
-  line-height: 1.1;
-  white-space: nowrap;
-}
-
-.gn-page .bottom-nav a:hover {
-  opacity: 1;
-  transform: translateY(-1px);
-}
-
-.gn-page .bottom-nav a.active {
-  background: radial-gradient(circle at top, #f09300, #a85e00);
-  color: #101010;
-  border-color: rgba(255, 255, 255, 0.15);
-  opacity: 1;
-  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.75);
-}
-
 @media (min-width: 900px) {
-  .gn-page .primary-nav { display: flex; }
-  .gn-page .bottom-nav { display: none; }
-  .gn-shell { padding-bottom: 36px; }
   .gn-layout {
     grid-template-columns: minmax(280px, 330px) 1fr;
     align-items: start;
@@ -200,8 +91,11 @@ html, body {
   .gn-table-wrap { display: block !important; }
 }
 
+@media (min-width: 960px) {
+  .gn-shell { padding-bottom: 36px; }
+}
+
 @media (max-width: 899px) {
   .gn-table-wrap { display: none !important; }
   .gn-cards { display: grid !important; }
-  .gn-page .bottom-nav { display: flex; }
 }

--- a/grand-national-picker.html
+++ b/grand-national-picker.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="home.css">
   <link rel="stylesheet" href="grand-national-picker.css">
 </head>
 <body class="home gn-page">


### PR DESCRIPTION
### Motivation
- Fix the mobile bottom navigation on `/grand-national-picker.html` so it behaves exactly like the homepage (sticky/fixed at the bottom of the viewport and visible while scrolling). 
- Reuse the homepage implementation to remove duplicated page-local nav CSS that caused behaviour drift and styling mismatches. 

### Description
- Include the shared homepage stylesheet by adding `home.css` to `grand-national-picker.html` so the page uses the same `.bottom-nav`/topbar implementation as the homepage. 
- Remove the duplicated topbar/primary-nav/bottom-nav CSS blocks from `grand-national-picker.css`, leaving the Grand National Picker-specific layout and component styles intact. 
- Adjust the shell bottom-padding breakpoint (`.gn-shell` padding preserved via a `@media (min-width: 960px)` rule) so mobile/tablet keep enough bottom space for the fixed nav while desktop padding remains tighter. 
- Changes are limited to `grand-national-picker.html` and `grand-national-picker.css`. 

### Testing
- Ran `rg -n "bottom-nav|primary-nav|home-topbar"` to verify nav selectors are now provided by the shared stylesheet and the page-local duplicates were removed, which succeeded. 
- Inspected produced diffs with `git diff -- grand-national-picker.html grand-national-picker.css` to confirm the `home.css` include and CSS removals, which succeeded. 
- Verified repository state with `git status --short` and committed the changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e8b6c274832fa8859439054666cc)