### PR TITLE
Add mobile-first /hda-value2 Priority Stack + Shortlist page

### DIFF
--- a/hda-value2/index.html
+++ b/hda-value2/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MC Predict | Top Value Bets</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;600;700;800&display=swap">
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <p class="eyebrow">HDA Value 2.0</p>
+      <h1>🔥 Top value bets today</h1>
+      <p class="subtitle">Ranked by model edge vs market</p>
+    </header>
+
+    <section class="filter-bar" aria-label="filters">
+      <div class="filter-group">
+        <span class="filter-label">Day</span>
+        <div id="dayFilters" class="pill-row"></div>
+      </div>
+      <div class="filter-group">
+        <span class="filter-label">Result</span>
+        <div id="resultFilters" class="pill-row"></div>
+      </div>
+    </section>
+
+    <section id="featuredSection" class="featured-section"></section>
+
+    <section class="tier-section">
+      <h2>🔥 Strong Value</h2>
+      <div id="tier1List" class="card-list"></div>
+    </section>
+
+    <section class="tier-section">
+      <h2>⭐ Good Value</h2>
+      <div id="tier2List" class="card-list"></div>
+    </section>
+
+    <section class="tier-section tier-section--collapsible">
+      <button id="tier3Toggle" class="tier-toggle" type="button" aria-expanded="false">
+        ▼ More Picks (0)
+      </button>
+      <div id="tier3List" class="card-list hidden"></div>
+    </section>
+
+    <section class="tier-section tier-section--collapsible">
+      <button id="overflowToggle" class="tier-toggle" type="button" aria-expanded="false">
+        ▼ Remaining Picks (0)
+      </button>
+      <div id="overflowList" class="card-list hidden"></div>
+    </section>
+
+    <div id="statusMsg" class="status-msg" role="status" aria-live="polite"></div>
+  </main>
+
+  <aside id="shortlistBar" class="shortlist-bar hidden" aria-live="polite">
+    <div>
+      <strong id="shortlistCount">0 picks</strong>
+      <p id="shortlistOdds">Est. Odds: 1.00</p>
+    </div>
+    <button id="viewShortlistBtn" type="button" class="btn-primary">View Shortlist</button>
+  </aside>
+
+  <dialog id="shortlistModal" class="shortlist-modal">
+    <div class="modal-head">
+      <h3>Your Shortlist</h3>
+      <button id="closeModalBtn" class="icon-btn" type="button" aria-label="Close">✕</button>
+    </div>
+    <div id="shortlistItems" class="modal-list"></div>
+    <div class="modal-foot">
+      <p id="modalOdds">Combined Odds: 1.00</p>
+      <div class="modal-actions">
+        <button id="copyPicksBtn" type="button" class="btn-secondary">Copy Picks</button>
+        <button id="clearPicksBtn" type="button" class="btn-danger">Clear</button>
+      </div>
+    </div>
+  </dialog>
+
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/hda-value2/script.js
+++ b/hda-value2/script.js
@@ -1,0 +1,350 @@
+const CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=1994550040&single=true&output=csv";
+const REQUIRED_FIELDS = [
+  "home_team", "away_team", "result", "league", "date",
+  "my_probability", "bookies_price", "my_price", "value"
+];
+const DAY_OPTIONS = ["Sat", "Sun", "Fri", "Mon"];
+const RESULT_OPTIONS = ["HOME WIN", "AWAY WIN"];
+const SHORTLIST_KEY = "mcp_hda_value2_shortlist";
+
+let allPicks = [];
+let activeDays = new Set();
+let activeResults = new Set();
+let shortlist = [];
+
+const dom = {
+  featuredSection: document.getElementById("featuredSection"),
+  dayFilters: document.getElementById("dayFilters"),
+  resultFilters: document.getElementById("resultFilters"),
+  tier1List: document.getElementById("tier1List"),
+  tier2List: document.getElementById("tier2List"),
+  tier3List: document.getElementById("tier3List"),
+  tier3Toggle: document.getElementById("tier3Toggle"),
+  overflowList: document.getElementById("overflowList"),
+  overflowToggle: document.getElementById("overflowToggle"),
+  statusMsg: document.getElementById("statusMsg"),
+  shortlistBar: document.getElementById("shortlistBar"),
+  shortlistCount: document.getElementById("shortlistCount"),
+  shortlistOdds: document.getElementById("shortlistOdds"),
+  viewShortlistBtn: document.getElementById("viewShortlistBtn"),
+  shortlistModal: document.getElementById("shortlistModal"),
+  shortlistItems: document.getElementById("shortlistItems"),
+  modalOdds: document.getElementById("modalOdds"),
+  closeModalBtn: document.getElementById("closeModalBtn"),
+  copyPicksBtn: document.getElementById("copyPicksBtn"),
+  clearPicksBtn: document.getElementById("clearPicksBtn")
+};
+
+function parseNumber(value) {
+  const n = parseFloat(String(value || "").replace(/[^0-9.-]/g, ""));
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeResult(value) {
+  return String(value || "").trim().toUpperCase();
+}
+
+function dayFromDate(dateStr) {
+  if (!dateStr) return "";
+  const parsed = new Date(dateStr);
+  if (Number.isNaN(parsed.getTime())) {
+    return String(dateStr).trim().slice(0, 3);
+  }
+  return parsed.toLocaleDateString("en-GB", { weekday: "short", timeZone: "UTC" });
+}
+
+function moneyTier(value) {
+  if (value >= 10) return "💰💰💰";
+  if (value >= 7) return "💰💰";
+  return "💰";
+}
+
+function impliedProbability(bookiesPrice) {
+  if (bookiesPrice <= 0) return 0;
+  return (1 / bookiesPrice) * 100;
+}
+
+function buildFilters() {
+  dom.dayFilters.innerHTML = DAY_OPTIONS.map((day) => `
+    <button class="pill" data-day="${day}" type="button">${day}</button>
+  `).join("");
+
+  dom.resultFilters.innerHTML = RESULT_OPTIONS.map((result) => `
+    <button class="pill" data-result="${result}" type="button">${result === "HOME WIN" ? "Home Win" : "Away Win"}</button>
+  `).join("");
+
+  dom.dayFilters.addEventListener("click", (event) => {
+    const btn = event.target.closest("button[data-day]");
+    if (!btn) return;
+    const day = btn.dataset.day;
+    activeDays.has(day) ? activeDays.delete(day) : activeDays.add(day);
+    btn.classList.toggle("active");
+    render();
+  });
+
+  dom.resultFilters.addEventListener("click", (event) => {
+    const btn = event.target.closest("button[data-result]");
+    if (!btn) return;
+    const result = btn.dataset.result;
+    activeResults.has(result) ? activeResults.delete(result) : activeResults.add(result);
+    btn.classList.toggle("active");
+    render();
+  });
+}
+
+function pickId(pick) {
+  return `${pick.date}|${pick.home_team}|${pick.away_team}|${pick.result}`;
+}
+
+function addToShortlist(pick) {
+  const id = pickId(pick);
+  if (shortlist.some((item) => item.id === id)) {
+    setStatus("Pick already added.");
+    return;
+  }
+  shortlist.push({
+    id,
+    fixture: `${pick.home_team} vs ${pick.away_team}`,
+    result: pick.result,
+    bookies_price: pick.bookies_price
+  });
+  persistShortlist();
+  updateShortlistUI();
+  setStatus("Added to shortlist.");
+}
+
+function setStatus(message) {
+  dom.statusMsg.textContent = message;
+  window.clearTimeout(setStatus.timer);
+  setStatus.timer = window.setTimeout(() => {
+    dom.statusMsg.textContent = "";
+  }, 1500);
+}
+
+function persistShortlist() {
+  localStorage.setItem(SHORTLIST_KEY, JSON.stringify(shortlist));
+}
+
+function loadShortlist() {
+  try {
+    shortlist = JSON.parse(localStorage.getItem(SHORTLIST_KEY) || "[]");
+    if (!Array.isArray(shortlist)) shortlist = [];
+  } catch {
+    shortlist = [];
+  }
+}
+
+function shortlistCombinedOdds() {
+  return shortlist.reduce((acc, item) => acc * parseNumber(item.bookies_price), 1);
+}
+
+function updateShortlistUI() {
+  const count = shortlist.length;
+  if (count === 0) {
+    dom.shortlistBar.classList.add("hidden");
+  } else {
+    dom.shortlistBar.classList.remove("hidden");
+  }
+
+  const odds = shortlistCombinedOdds();
+  dom.shortlistCount.textContent = `${count} pick${count === 1 ? "" : "s"}`;
+  dom.shortlistOdds.textContent = `Est. Odds: ${odds.toFixed(2)}`;
+  dom.modalOdds.textContent = `Combined Odds: ${odds.toFixed(2)}`;
+
+  if (count === 0) {
+    dom.shortlistItems.innerHTML = '<p class="subtitle">No picks selected yet.</p>';
+    return;
+  }
+
+  dom.shortlistItems.innerHTML = shortlist.map((item) => `
+    <article class="modal-item">
+      <div>
+        <p>${item.fixture}</p>
+        <p class="subtitle">${item.result}</p>
+      </div>
+      <p>@${parseNumber(item.bookies_price).toFixed(2)}</p>
+    </article>
+  `).join("");
+}
+
+function copyPicks() {
+  if (!shortlist.length) {
+    setStatus("No picks to copy.");
+    return;
+  }
+
+  const lines = shortlist.map((item) => `${item.fixture} - ${item.result === "HOME WIN" ? "Home Win" : "Away Win"} @${parseNumber(item.bookies_price).toFixed(2)}`);
+  lines.push(`Total Odds: ${shortlistCombinedOdds().toFixed(2)}`);
+  const payload = lines.join("\n");
+
+  navigator.clipboard.writeText(payload)
+    .then(() => setStatus("Picks copied."))
+    .catch(() => setStatus("Unable to copy on this browser."));
+}
+
+function filteredSortedPicks() {
+  return allPicks
+    .filter((pick) => (activeDays.size === 0 || activeDays.has(pick.day)))
+    .filter((pick) => (activeResults.size === 0 || activeResults.has(pick.result)))
+    .sort((a, b) => b.value - a.value);
+}
+
+function createPickCard(pick) {
+  const card = document.createElement("article");
+  card.className = "pick-card";
+  card.innerHTML = `
+    <div class="pick-card-main">
+      <p class="pick-fixture">${pick.home_team} vs ${pick.away_team}</p>
+      <p class="pick-sub">${pick.result} • ${pick.league || "League n/a"}</p>
+    </div>
+    <div class="pick-meta">
+      <p class="pick-value">${pick.value.toFixed(2)}%</p>
+      <p class="pick-money">${moneyTier(pick.value)}</p>
+      <button class="add-btn" type="button" aria-label="Add ${pick.home_team} vs ${pick.away_team}">+</button>
+    </div>
+  `;
+  card.querySelector(".add-btn").addEventListener("click", () => addToShortlist(pick));
+  return card;
+}
+
+function renderFeatured(pick) {
+  if (!pick) {
+    dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">No picks match your filters.</p></article>';
+    return;
+  }
+
+  dom.featuredSection.innerHTML = `
+    <article class="featured-card">
+      <div class="featured-top">
+        <div>
+          <h2 class="fixture">${pick.home_team} vs ${pick.away_team}</h2>
+          <p class="result-tag">${pick.result}</p>
+        </div>
+        <div>
+          <p class="value-big">${pick.value.toFixed(2)}%</p>
+          <p class="money">${moneyTier(pick.value)}</p>
+        </div>
+      </div>
+      <div class="featured-grid">
+        <div class="stat"><span>Model Price</span><strong>${pick.my_price.toFixed(2)}</strong></div>
+        <div class="stat"><span>Bookie Price</span><strong>${pick.bookies_price.toFixed(2)}</strong></div>
+        <div class="stat"><span>Model Probability</span><strong>${pick.my_probability.toFixed(2)}%</strong></div>
+        <div class="stat"><span>Implied Probability</span><strong>${impliedProbability(pick.bookies_price).toFixed(2)}%</strong></div>
+      </div>
+      <div style="margin-top: 10px;">
+        <button id="featuredAddBtn" type="button" class="btn-primary">+ Shortlist</button>
+      </div>
+    </article>
+  `;
+
+  document.getElementById("featuredAddBtn").addEventListener("click", () => addToShortlist(pick));
+}
+
+function fillList(node, picks) {
+  node.innerHTML = "";
+  if (!picks.length) {
+    node.innerHTML = '<p class="subtitle">No picks in this tier.</p>';
+    return;
+  }
+  picks.forEach((pick) => node.appendChild(createPickCard(pick)));
+}
+
+function render() {
+  const picks = filteredSortedPicks();
+  renderFeatured(picks[0]);
+
+  const visibleRemainder = picks.slice(1, 10);
+  const overflow = picks.slice(10);
+
+  const tier1 = visibleRemainder.filter((pick) => pick.value >= 10);
+  const tier2 = visibleRemainder.filter((pick) => pick.value >= 7 && pick.value < 10);
+  const tier3 = visibleRemainder.filter((pick) => pick.value < 7);
+
+  fillList(dom.tier1List, tier1);
+  fillList(dom.tier2List, tier2);
+  fillList(dom.tier3List, tier3);
+  fillList(dom.overflowList, overflow);
+
+  dom.tier3Toggle.textContent = `▼ More Picks (${tier3.length})`;
+  dom.overflowToggle.textContent = `▼ Remaining Picks (${overflow.length})`;
+}
+
+function mapRows(rows) {
+  const headerIndex = rows.findIndex((row) => REQUIRED_FIELDS.every((field) => row.includes(field)));
+  if (headerIndex === -1) throw new Error("Header row with required fields was not found.");
+
+  const headers = rows[headerIndex];
+  const dataRows = rows.slice(headerIndex + 1);
+
+  return dataRows
+    .filter((row) => row.length)
+    .map((row) => {
+      const record = {};
+      headers.forEach((header, idx) => {
+        record[header] = row[idx];
+      });
+      return {
+        home_team: String(record.home_team || "").trim(),
+        away_team: String(record.away_team || "").trim(),
+        result: normalizeResult(record.result),
+        league: String(record.league || "").trim(),
+        date: String(record.date || "").trim(),
+        day: dayFromDate(record.date),
+        my_probability: parseNumber(record.my_probability),
+        bookies_price: parseNumber(record.bookies_price),
+        my_price: parseNumber(record.my_price),
+        value: parseNumber(record.value)
+      };
+    })
+    .filter((pick) => pick.home_team && pick.away_team && pick.result && pick.bookies_price > 0);
+}
+
+function attachStaticHandlers() {
+  dom.tier3Toggle.addEventListener("click", () => {
+    const open = dom.tier3List.classList.toggle("hidden");
+    dom.tier3Toggle.setAttribute("aria-expanded", String(!open));
+  });
+
+  dom.overflowToggle.addEventListener("click", () => {
+    const open = dom.overflowList.classList.toggle("hidden");
+    dom.overflowToggle.setAttribute("aria-expanded", String(!open));
+  });
+
+  dom.viewShortlistBtn.addEventListener("click", () => dom.shortlistModal.showModal());
+  dom.closeModalBtn.addEventListener("click", () => dom.shortlistModal.close());
+  dom.clearPicksBtn.addEventListener("click", () => {
+    shortlist = [];
+    persistShortlist();
+    updateShortlistUI();
+    setStatus("Shortlist cleared.");
+  });
+  dom.copyPicksBtn.addEventListener("click", copyPicks);
+}
+
+function loadData() {
+  Papa.parse(CSV_URL, {
+    download: true,
+    skipEmptyLines: true,
+    complete: (results) => {
+      try {
+        allPicks = mapRows(results.data);
+        render();
+      } catch (error) {
+        dom.featuredSection.innerHTML = `<article class="featured-card"><p class="subtitle">Failed to process feed: ${error.message}</p></article>`;
+      }
+    },
+    error: () => {
+      dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Failed to load live feed.</p></article>';
+    }
+  });
+}
+
+function init() {
+  buildFilters();
+  attachStaticHandlers();
+  loadShortlist();
+  updateShortlistUI();
+  loadData();
+}
+
+init();

--- a/hda-value2/styles.css
+++ b/hda-value2/styles.css
@@ -1,0 +1,186 @@
+:root {
+  --bg: #18181a;
+  --panel: #222225;
+  --panel-2: #2d2d31;
+  --text: #e8e8e8;
+  --muted: #a2a2a8;
+  --accent: #f09300;
+  --accent-2: #ffae33;
+  --danger: #ff5d5d;
+  --ok: #40c456;
+  --border: rgba(255, 255, 255, 0.08);
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: 'Proxima Nova', Arial, sans-serif;
+  background: radial-gradient(circle at top left, #303034 0, #1e1e21 42%, #131315 100%);
+  color: var(--text);
+  padding: 0 0 96px;
+}
+
+.page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 16px 12px 24px;
+}
+
+.hero h1 {
+  margin: 8px 0;
+  font-size: 1.6rem;
+  line-height: 1.2;
+}
+.eyebrow { color: var(--accent-2); margin: 0; letter-spacing: 0.08em; text-transform: uppercase; font-size: 0.74rem; }
+.subtitle { margin: 0; color: var(--muted); font-size: 0.96rem; }
+
+.filter-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  padding: 10px 0;
+  margin: 14px 0;
+  background: linear-gradient(to bottom, rgba(24, 24, 26, 0.95), rgba(24, 24, 26, 0.85));
+  backdrop-filter: blur(8px);
+}
+.filter-group + .filter-group { margin-top: 8px; }
+.filter-label { display: block; color: var(--muted); font-size: 0.8rem; margin-bottom: 6px; }
+.pill-row {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+.pill-row::-webkit-scrollbar { display: none; }
+.pill {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-weight: 700;
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+.pill.active {
+  color: #111;
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+}
+
+.featured-card, .pick-card, .tier-toggle, .shortlist-bar, .shortlist-modal {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+}
+.featured-card {
+  background: radial-gradient(circle at top right, rgba(240, 147, 0, 0.22), rgba(20, 20, 23, 0.95));
+  padding: 14px;
+  margin-bottom: 16px;
+}
+.featured-top { display: flex; justify-content: space-between; gap: 10px; align-items: center; }
+.fixture { margin: 0; font-size: 1.1rem; }
+.result-tag { margin: 6px 0 0; color: var(--muted); font-size: 0.86rem; text-transform: uppercase; }
+.value-big { font-size: 1.7rem; font-weight: 800; color: var(--accent-2); margin: 2px 0; text-align: right; }
+.money { font-size: 1rem; margin: 0; text-align: right; }
+
+.featured-grid {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.stat {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 12px;
+  padding: 8px;
+}
+.stat span { display: block; color: var(--muted); font-size: 0.78rem; }
+.stat strong { font-size: 0.95rem; }
+
+.btn-primary, .btn-secondary, .btn-danger, .add-btn, .icon-btn {
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+.btn-primary, .add-btn {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #111;
+  padding: 11px 14px;
+}
+.btn-secondary { background: #34343a; color: var(--text); padding: 10px 14px; }
+.btn-danger { background: rgba(255, 93, 93, 0.16); color: #ff9f9f; padding: 10px 14px; }
+.icon-btn { background: transparent; color: var(--muted); padding: 4px 8px; font-size: 1rem; }
+
+.tier-section { margin-bottom: 14px; }
+.tier-section h2 { margin: 0 0 8px; font-size: 1rem; }
+.card-list { display: grid; gap: 10px; }
+.pick-card {
+  background: var(--panel);
+  padding: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.pick-card-main { min-width: 0; }
+.pick-fixture { margin: 0; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pick-sub { margin: 4px 0 0; color: var(--muted); font-size: 0.8rem; text-transform: uppercase; }
+.pick-meta { text-align: right; }
+.pick-value { margin: 0; color: var(--accent-2); font-weight: 800; font-size: 1rem; }
+.pick-money { margin: 2px 0 8px; font-size: 0.85rem; }
+.add-btn { min-width: 42px; padding: 9px 10px; }
+
+.tier-toggle {
+  width: 100%;
+  background: var(--panel-2);
+  color: var(--text);
+  text-align: left;
+  padding: 11px;
+  font-weight: 700;
+}
+
+.shortlist-bar {
+  position: fixed;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  z-index: 30;
+  background: rgba(18, 18, 20, 0.98);
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55);
+}
+.shortlist-bar p { margin: 4px 0 0; color: var(--muted); font-size: 0.8rem; }
+
+.shortlist-modal {
+  width: min(560px, calc(100vw - 20px));
+  background: #1b1b1f;
+  color: var(--text);
+  padding: 14px;
+}
+.shortlist-modal::backdrop { background: rgba(0, 0, 0, 0.75); }
+.modal-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.modal-head h3 { margin: 0; }
+.modal-list { max-height: 46vh; overflow-y: auto; display: grid; gap: 8px; }
+.modal-item {
+  display: flex; justify-content: space-between; gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 12px; padding: 8px;
+}
+.modal-item p { margin: 0; font-size: 0.88rem; }
+.modal-foot { border-top: 1px solid var(--border); margin-top: 10px; padding-top: 10px; }
+.modal-foot p { margin: 0 0 8px; font-weight: 700; }
+.modal-actions { display: flex; gap: 8px; }
+
+.status-msg { min-height: 20px; color: var(--ok); font-size: 0.82rem; }
+.hidden { display: none !important; }
+
+@media (min-width: 768px) {
+  .page { padding: 20px 16px 30px; }
+  .hero h1 { font-size: 2rem; }
+  .pick-card { padding: 12px; }
+}


### PR DESCRIPTION
### Motivation
- Replace the existing table-first view with a mobile-first "Priority Stack + Shortlist" UI so mobile users can scan top value bets quickly and build multi-pick shortlists. 
- Keep the exact same Google Sheets CSV source and data structure so downstream tooling is unchanged. 
- Preserve the existing stack (vanilla HTML/CSS/JS + PapaParse) and MC Predict dark/orange visual language while improving touch targets and layout.

### Description
- Added a new standalone page with `hda-value2/index.html`, `hda-value2/styles.css`, and `hda-value2/script.js` implementing the requested page structure (header, sticky filter pills, featured pick, tiered lists, collapsed overflow, shortlist bar and modal). 
- Wired the page to the same sheet CSV (`gid=1994550040`) via PapaParse and implemented robust header detection that maps the required fields (`home_team`, `away_team`, `result`, `league`, `date`, `my_probability`, `bookies_price`, `my_price`, `value`). 
- Implemented mobile-first UI and behaviour: sticky day/result filter pills, featured top-1 card with implied probability and model/bookie prices, tier buckets (>=10%, 7–9.99%, <7%), default top-10 visible with collapsed remaining picks, and money-tier icons. 
- Built shortlist functionality with localStorage persistence, duplicate prevention, sticky footer summary showing estimated combined odds (multiplication of `bookies_price`), a modal listing picks, `Copy Picks` payload formatting, and `Clear` action.

### Testing
- Ran a syntax check on the client script with `node --check hda-value2/script.js`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcea6c7414832f80b1f2934c402963)