### PR TITLE
Rewrite /hda-value2/script.js with robust CSV parsing, rendering, and shortlist

### DIFF
--- a/hda-value2/script.js
+++ b/hda-value2/script.js
@@ -1,13 +1,29 @@
 const CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=1994550040&single=true&output=csv";
-const DAY_OPTIONS = ["Sat", "Sun", "Fri", "Mon"];
-const RESULT_OPTIONS = ["HOME WIN", "AWAY WIN"];
 const SHORTLIST_KEY = "mcp_hda_value2_shortlist";
 
-let allPicks = [];
-let activeDays = new Set(DAY_OPTIONS.map((day) => normalizeDay(day)));
-let activeResults = new Set(RESULT_OPTIONS.map((result) => normalizeResult(result)));
-let shortlist = [];
-let loadState = "loading"; // loading | ready | error
+const DAY_OPTIONS = ["Sat", "Sun", "Fri", "Mon"];
+const RESULT_OPTIONS = ["Home Win", "Away Win"];
+
+const FIELD_ALIASES = {
+  date: ["date"],
+  day: ["day"],
+  league: ["league"],
+  home_team: ["home team", "hometeam", "home_team"],
+  away_team: ["away team", "awayteam", "away_team"],
+  result: ["result"],
+  my_probability: ["my probability", "myprobability", "probability", "my_prob"],
+  bookies_price: ["bookies price", "bookie price", "bookiesprice", "bookieprice", "odds"],
+  my_price: ["my price", "myprice", "model price", "modelprice"],
+  value: ["value", "edge", "value %", "value%"]
+};
+
+const state = {
+  allRows: [],
+  selectedDays: new Set(),
+  selectedResults: new Set(),
+  shortlist: [],
+  loadState: "loading"
+};
 
 const dom = {
   featuredSection: document.getElementById("featuredSection"),
@@ -31,27 +47,6 @@ const dom = {
   copyPicksBtn: document.getElementById("copyPicksBtn"),
   clearPicksBtn: document.getElementById("clearPicksBtn")
 };
-
-function parseNumber(value) {
-  const normalized = String(value || "")
-    .replace(/%/g, "")
-    .replace(/,/g, "")
-    .trim();
-  const n = parseFloat(normalized);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function safeNumber(value, fallback = 0) {
-  return Number.isFinite(value) ? value : fallback;
-}
-
-function normalizeResult(value) {
-  return String(value || "").trim().replace(/\s+/g, " ").toUpperCase();
-}
-
-function normalizeDay(value) {
-  return String(value || "").trim().slice(0, 3).toUpperCase();
-}
 
 function normaliseKey(key) {
   return String(key || "")
@@ -80,340 +75,306 @@ function getField(row, keyMap, aliases) {
   return "";
 }
 
-function dayFromDate(dateStr, fallbackDay) {
-  if (fallbackDay) {
-    const normalizedFallback = normalizeDay(fallbackDay);
-    if (normalizedFallback) return normalizedFallback;
-  }
-
-  const raw = String(dateStr || "").trim();
-  if (!raw) return "";
-
-  const parsed = new Date(raw);
-  if (Number.isNaN(parsed.getTime())) return normalizeDay(raw);
-
-  return parsed.toLocaleDateString("en-GB", { weekday: "short", timeZone: "UTC" }).toUpperCase();
+function parseNumber(value) {
+  const cleaned = String(value || "")
+    .replace(/%/g, "")
+    .replace(/,/g, "")
+    .trim();
+  const num = parseFloat(cleaned);
+  return Number.isFinite(num) ? num : 0;
 }
 
-function moneyTier(value) {
-  if (value >= 10) return "💰💰💰";
-  if (value >= 7) return "💰💰";
-  return "💰";
+function normDayLabel(day) {
+  return String(day || "").trim().slice(0, 3).toLowerCase();
+}
+
+function normResultLabel(result) {
+  return String(result || "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function prettyResult(result) {
+  const value = normResultLabel(result);
+  if (value === "home win") return "Home Win";
+  if (value === "away win") return "Away Win";
+  return String(result || "").trim() || "Unknown";
+}
+
+function formatOdds(value) {
+  return parseNumber(value).toFixed(2);
+}
+
+function pickId(pick) {
+  return [pick.date, pick.home_team, pick.away_team, pick.result].join("|");
+}
+
+function showStatus(message) {
+  if (!dom.statusMsg) return;
+  dom.statusMsg.textContent = message;
+  clearTimeout(showStatus.timer);
+  showStatus.timer = setTimeout(() => {
+    dom.statusMsg.textContent = "";
+  }, 1600);
 }
 
 function impliedProbability(bookiesPrice) {
-  if (!Number.isFinite(bookiesPrice) || bookiesPrice <= 0) return NaN;
-  return (1 / bookiesPrice) * 100;
+  const price = parseNumber(bookiesPrice);
+  if (price <= 0) return "—";
+  return `${((1 / price) * 100).toFixed(2)}%`;
+}
+
+function moneyTierIcons(value) {
+  const num = parseNumber(value);
+  if (num >= 10) return "💰💰💰";
+  if (num >= 7) return "💰💰";
+  return "💰";
 }
 
 function setLoadingState() {
-  dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Loading picks...</p></article>';
+  if (dom.featuredSection) {
+    dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Loading picks...</p></article>';
+  }
 }
 
-function setErrorState() {
-  dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Unable to load picks right now.</p></article>';
+function setFeedFailureState() {
+  if (dom.featuredSection) {
+    dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Unable to load picks right now.</p></article>';
+  }
   fillList(dom.tier1List, []);
   fillList(dom.tier2List, []);
   fillList(dom.tier3List, []);
   fillList(dom.overflowList, []);
-  dom.tier3Toggle.textContent = "▼ More Picks (0)";
-  dom.overflowToggle.textContent = "▼ Remaining Picks (0)";
+  if (dom.tier3Toggle) dom.tier3Toggle.textContent = "▼ More Picks (0)";
+  if (dom.overflowToggle) dom.overflowToggle.textContent = "▼ Remaining Picks (0)";
 }
 
-function buildFilters() {
-  dom.dayFilters.innerHTML = DAY_OPTIONS.map((day) => {
-    const normalized = normalizeDay(day);
-    return `<button class="pill active" data-day="${normalized}" type="button">${day}</button>`;
-  }).join("");
+function normaliseRow(row, index) {
+  const keyMap = buildKeyMap(row);
 
-  dom.resultFilters.innerHTML = RESULT_OPTIONS.map((result) => {
-    const label = result === "HOME WIN" ? "Home Win" : "Away Win";
-    return `<button class="pill active" data-result="${normalizeResult(result)}" type="button">${label}</button>`;
-  }).join("");
+  const date = String(getField(row, keyMap, FIELD_ALIASES.date)).trim();
+  const dayRaw = String(getField(row, keyMap, FIELD_ALIASES.day)).trim();
+  const day = dayRaw ? dayRaw : date;
 
-  dom.dayFilters.addEventListener("click", (event) => {
-    const btn = event.target.closest("button[data-day]");
-    if (!btn) return;
-    const day = normalizeDay(btn.dataset.day);
-    activeDays.has(day) ? activeDays.delete(day) : activeDays.add(day);
-    btn.classList.toggle("active", activeDays.has(day));
-    render();
-  });
-
-  dom.resultFilters.addEventListener("click", (event) => {
-    const btn = event.target.closest("button[data-result]");
-    if (!btn) return;
-    const result = normalizeResult(btn.dataset.result);
-    activeResults.has(result) ? activeResults.delete(result) : activeResults.add(result);
-    btn.classList.toggle("active", activeResults.has(result));
-    render();
-  });
-}
-
-function pickId(pick) {
-  return `${pick.date}|${pick.home_team}|${pick.away_team}|${pick.result}`;
-}
-
-function addToShortlist(pick) {
-  const id = pickId(pick);
-  if (shortlist.some((item) => item.id === id)) {
-    setStatus("Pick already added.");
-    return;
-  }
-
-  shortlist.push({
-    id,
-    fixture: `${pick.home_team} vs ${pick.away_team}`,
-    result: pick.result,
-    bookies_price: pick.bookies_price
-  });
-
-  persistShortlist();
-  updateShortlistUI();
-  setStatus("Added to shortlist.");
-}
-
-function setStatus(message) {
-  dom.statusMsg.textContent = message;
-  window.clearTimeout(setStatus.timer);
-  setStatus.timer = window.setTimeout(() => {
-    dom.statusMsg.textContent = "";
-  }, 1500);
-}
-
-function persistShortlist() {
-  localStorage.setItem(SHORTLIST_KEY, JSON.stringify(shortlist));
-}
-
-function loadShortlist() {
-  try {
-    shortlist = JSON.parse(localStorage.getItem(SHORTLIST_KEY) || "[]");
-    if (!Array.isArray(shortlist)) shortlist = [];
-  } catch {
-    shortlist = [];
-  }
-}
-
-function shortlistCombinedOdds() {
-  return shortlist.reduce((acc, item) => {
-    const price = parseNumber(item.bookies_price);
-    return Number.isFinite(price) && price > 0 ? acc * price : acc;
-  }, 1);
-}
-
-function updateShortlistUI() {
-  const count = shortlist.length;
-  dom.shortlistBar.classList.toggle("hidden", count === 0);
-
-  const odds = shortlistCombinedOdds();
-  dom.shortlistCount.textContent = `${count} pick${count === 1 ? "" : "s"}`;
-  dom.shortlistOdds.textContent = `Est. Odds: ${odds.toFixed(2)}`;
-  dom.modalOdds.textContent = `Combined Odds: ${odds.toFixed(2)}`;
-
-  if (!count) {
-    dom.shortlistItems.innerHTML = '<p class="subtitle">No picks selected yet.</p>';
-    return;
-  }
-
-  dom.shortlistItems.innerHTML = shortlist.map((item) => `
-    <article class="modal-item">
-      <div>
-        <p>${item.fixture}</p>
-        <p class="subtitle">${item.result}</p>
-      </div>
-      <p>@${safeNumber(parseNumber(item.bookies_price), 0).toFixed(2)}</p>
-    </article>
-  `).join("");
-}
-
-function copyPicks() {
-  if (!shortlist.length) {
-    setStatus("No picks to copy.");
-    return;
-  }
-
-  const lines = shortlist.map((item) => `${item.fixture} - ${item.result === "HOME WIN" ? "Home Win" : "Away Win"} @${safeNumber(parseNumber(item.bookies_price), 0).toFixed(2)}`);
-  lines.push(`Total Odds: ${shortlistCombinedOdds().toFixed(2)}`);
-
-  navigator.clipboard.writeText(lines.join("\n"))
-    .then(() => setStatus("Picks copied."))
-    .catch(() => setStatus("Unable to copy on this browser."));
-}
-
-const FIELD_ALIASES = {
-  date: ["date"],
-  day: ["day"],
-  league: ["league"],
-  home_team: ["home team", "hometeam", "home_team", "home"],
-  away_team: ["away team", "awayteam", "away_team", "away"],
-  result: ["result", "pick", "selection"],
-  my_probability: ["my probability", "myprobability", "probability", "my_prob", "my_probability"],
-  bookies_price: ["bookies price", "bookie price", "bookiesprice", "bookieprice", "odds", "bookies_price"],
-  my_price: ["my price", "myprice", "model price", "modelprice", "my_price"],
-  value: ["value", "edge", "value %", "value%"]
-};
-
-function normaliseRow(row, keyMap) {
-  const date = String(getField(row, keyMap, FIELD_ALIASES.date) || "").trim();
-  const day = dayFromDate(date, getField(row, keyMap, FIELD_ALIASES.day));
-  const homeTeam = String(getField(row, keyMap, FIELD_ALIASES.home_team) || "").trim();
-  const awayTeam = String(getField(row, keyMap, FIELD_ALIASES.away_team) || "").trim();
-  const result = normalizeResult(getField(row, keyMap, FIELD_ALIASES.result));
-
-  const pick = {
+  const cleanRow = {
+    id: `${index}-${pickId({
+      date,
+      home_team: String(getField(row, keyMap, FIELD_ALIASES.home_team)).trim(),
+      away_team: String(getField(row, keyMap, FIELD_ALIASES.away_team)).trim(),
+      result: String(getField(row, keyMap, FIELD_ALIASES.result)).trim()
+    })}`,
     date,
-    day,
-    league: String(getField(row, keyMap, FIELD_ALIASES.league) || "").trim(),
-    home_team: homeTeam,
-    away_team: awayTeam,
-    result,
+    day: String(day).trim(),
+    league: String(getField(row, keyMap, FIELD_ALIASES.league)).trim(),
+    home_team: String(getField(row, keyMap, FIELD_ALIASES.home_team)).trim(),
+    away_team: String(getField(row, keyMap, FIELD_ALIASES.away_team)).trim(),
+    result: String(getField(row, keyMap, FIELD_ALIASES.result)).trim(),
     my_probability: parseNumber(getField(row, keyMap, FIELD_ALIASES.my_probability)),
     bookies_price: parseNumber(getField(row, keyMap, FIELD_ALIASES.bookies_price)),
     my_price: parseNumber(getField(row, keyMap, FIELD_ALIASES.my_price)),
     value: parseNumber(getField(row, keyMap, FIELD_ALIASES.value))
   };
 
-  const isEmpty = Object.values(row || {}).every((field) => String(field || "").trim() === "");
-  if (isEmpty) return null;
+  const missingRequired = !cleanRow.home_team
+    || !cleanRow.away_team
+    || !cleanRow.result
+    || cleanRow.bookies_price <= 0
+    || String(getField(row, keyMap, FIELD_ALIASES.value)).trim() === "";
 
-  if (!pick.home_team || !pick.away_team || !pick.result || String(getField(row, keyMap, FIELD_ALIASES.value) || "").trim() === "") return null;
-
-  return pick;
-}
-
-function rowsToObjects(rawRows) {
-  if (!Array.isArray(rawRows) || !rawRows.length) return [];
-  if (!Array.isArray(rawRows[0])) return rawRows;
-
-  const [headerRow, ...dataRows] = rawRows;
-  const headers = (headerRow || []).map((header, index) => String(header || `column_${index}`).trim());
-  return dataRows.map((row) => {
-    const mapped = {};
-    headers.forEach((header, index) => {
-      mapped[header] = row?.[index] ?? "";
-    });
-    return mapped;
-  });
+  return missingRequired ? null : cleanRow;
 }
 
 function loadCsvData() {
+  state.loadState = "loading";
   setLoadingState();
-  loadState = "loading";
 
   Papa.parse(CSV_URL, {
     download: true,
     header: true,
-    skipEmptyLines: "greedy",
+    skipEmptyLines: true,
     complete: (results) => {
       try {
-        const rawRows = Array.isArray(results.data) ? results.data : [];
-        const rows = rowsToObjects(rawRows).filter((row) => Object.values(row || {}).some((value) => String(value || "").trim() !== ""));
+        const parsedRows = Array.isArray(results?.data) ? results.data : [];
+        console.log("[hda-value2] Raw first row:", parsedRows[0] || null);
+        console.log("[hda-value2] Raw keys:", Object.keys(parsedRows[0] || {}));
 
-        console.log("Raw first row:", rows[0]);
-        console.log("Raw keys:", Object.keys(rows[0] || {}));
-        console.log("Raw first 3 rows:", rows.slice(0, 3));
-
-        if (!rows.length) {
-          console.error("[hda-value2] CSV parse produced no data rows.");
-          loadState = "error";
-          setErrorState();
-          return;
-        }
-
-        const keyMap = buildKeyMap(rows[0]);
-        console.log("Key map:", keyMap);
-
-        allPicks = rows
-          .map((row) => normaliseRow(row, keyMap))
+        const normalisedRows = parsedRows
+          .map((row, index) => normaliseRow(row, index))
           .filter(Boolean)
           .sort((a, b) => b.value - a.value);
 
-        console.log("First 5 normalised rows:", allPicks.slice(0, 5));
-        console.log("Valid row count:", allPicks.length);
+        console.log("[hda-value2] First 5 normalised rows:", normalisedRows.slice(0, 5));
+        console.log("[hda-value2] Valid row count:", normalisedRows.length);
 
-        if (!allPicks.length) {
-          loadState = "error";
-          setErrorState();
-          dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Unable to load valid picks right now.</p></article>';
-          return;
-        }
-
-        loadState = "ready";
+        state.allRows = normalisedRows;
+        state.loadState = "ready";
         render();
       } catch (error) {
-        console.error("[hda-value2] CSV parse error:", error);
-        loadState = "error";
-        setErrorState();
+        console.error("[hda-value2] Failed to process feed:", error);
+        state.loadState = "error";
+        setFeedFailureState();
       }
     },
     error: (error) => {
-      console.error("[hda-value2] CSV load error:", error);
-      loadState = "error";
-      setErrorState();
+      console.error("[hda-value2] Feed request failed:", error);
+      state.loadState = "error";
+      setFeedFailureState();
     }
   });
 }
 
-function applyFilters(picks) {
-  return picks
-    .filter((pick) => activeDays.size === 0 || activeDays.has(normalizeDay(pick.day)))
-    .filter((pick) => activeResults.size === 0 || activeResults.has(normalizeResult(pick.result)));
+function passesFilters(row) {
+  const dayMatch = state.selectedDays.size === 0 || state.selectedDays.has(normDayLabel(row.day));
+  const resultMatch = state.selectedResults.size === 0 || state.selectedResults.has(normResultLabel(row.result));
+  return dayMatch && resultMatch;
 }
 
-function splitIntoTiers(picks) {
-  return {
-    tier1: picks.filter((pick) => pick.value >= 10),
-    tier2: picks.filter((pick) => pick.value >= 7 && pick.value < 10),
-    tier3: picks.filter((pick) => pick.value < 7)
-  };
+function getVisibleRows() {
+  const filtered = state.allRows.filter(passesFilters);
+  console.log("[hda-value2] Filtered row count:", filtered.length);
+  return filtered;
 }
 
-function createPickCard(pick) {
+function createFilterButton(label, type) {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.className = "pill";
+  btn.textContent = label;
+
+  if (type === "day") btn.dataset.day = normDayLabel(label);
+  if (type === "result") btn.dataset.result = normResultLabel(label);
+
+  return btn;
+}
+
+function syncFilterButtonClasses() {
+  if (dom.dayFilters) {
+    dom.dayFilters.querySelectorAll("button[data-day]").forEach((btn) => {
+      btn.classList.toggle("active", state.selectedDays.has(btn.dataset.day));
+    });
+  }
+  if (dom.resultFilters) {
+    dom.resultFilters.querySelectorAll("button[data-result]").forEach((btn) => {
+      btn.classList.toggle("active", state.selectedResults.has(btn.dataset.result));
+    });
+  }
+}
+
+function initFilters() {
+  if (dom.dayFilters) {
+    dom.dayFilters.innerHTML = "";
+    DAY_OPTIONS.forEach((day) => dom.dayFilters.appendChild(createFilterButton(day, "day")));
+    dom.dayFilters.addEventListener("click", (event) => {
+      const btn = event.target.closest("button[data-day]");
+      if (!btn) return;
+      const key = btn.dataset.day;
+      if (state.selectedDays.has(key)) state.selectedDays.delete(key);
+      else state.selectedDays.add(key);
+      syncFilterButtonClasses();
+      render();
+    });
+  }
+
+  if (dom.resultFilters) {
+    dom.resultFilters.innerHTML = "";
+    RESULT_OPTIONS.forEach((result) => dom.resultFilters.appendChild(createFilterButton(result, "result")));
+    dom.resultFilters.addEventListener("click", (event) => {
+      const btn = event.target.closest("button[data-result]");
+      if (!btn) return;
+      const key = btn.dataset.result;
+      if (state.selectedResults.has(key)) state.selectedResults.delete(key);
+      else state.selectedResults.add(key);
+      syncFilterButtonClasses();
+      render();
+    });
+  }
+
+  syncFilterButtonClasses();
+}
+
+function toTier(row) {
+  if (row.value >= 10) return 1;
+  if (row.value >= 7) return 2;
+  return 3;
+}
+
+function splitRowsForRendering(rows) {
+  const featured = rows[0] || null;
+  const rest = rows.slice(1);
+
+  const visible = rest.slice(0, 10);
+  const overflow = rest.slice(10);
+
+  const tier1 = [];
+  const tier2 = [];
+  const tier3 = [];
+
+  visible.forEach((row) => {
+    const tier = toTier(row);
+    if (tier === 1) tier1.push(row);
+    else if (tier === 2) tier2.push(row);
+    else tier3.push(row);
+  });
+
+  return { featured, tier1, tier2, tier3, overflow };
+}
+
+function createPickCard(row) {
   const card = document.createElement("article");
   card.className = "pick-card";
 
   card.innerHTML = `
     <div class="pick-card-main">
-      <p class="pick-fixture">${pick.home_team} vs ${pick.away_team}</p>
-      <p class="pick-sub">${pick.result} • ${pick.league || "League n/a"}</p>
+      <p class="pick-fixture">${row.home_team} vs ${row.away_team}</p>
+      <p class="pick-sub">${prettyResult(row.result)}${row.league ? ` • ${row.league}` : ""}</p>
     </div>
     <div class="pick-meta">
-      <p class="pick-value">${safeNumber(pick.value, 0).toFixed(2)}%</p>
-      <p class="pick-money">${moneyTier(safeNumber(pick.value, 0))}</p>
-      <button class="add-btn" type="button" aria-label="Add ${pick.home_team} vs ${pick.away_team}">+</button>
+      <p class="pick-value">${row.value.toFixed(2)}%</p>
+      <p class="pick-money">${moneyTierIcons(row.value)}</p>
+      <button class="add-btn" type="button" aria-label="Add ${row.home_team} vs ${row.away_team}">+</button>
     </div>
   `;
 
-  card.querySelector(".add-btn").addEventListener("click", () => addToShortlist(pick));
+  const addBtn = card.querySelector(".add-btn");
+  if (addBtn) addBtn.addEventListener("click", () => addToShortlist(row));
+
   return card;
 }
 
-function renderFeaturedPick(pick) {
-  if (!pick) {
+function fillList(container, picks) {
+  if (!container) return;
+  container.innerHTML = "";
+  if (!picks.length) {
+    container.innerHTML = '<p class="subtitle">No picks in this tier.</p>';
+    return;
+  }
+  picks.forEach((pick) => container.appendChild(createPickCard(pick)));
+}
+
+function renderFeatured(row) {
+  if (!dom.featuredSection) return;
+
+  if (!row) {
     dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">No picks match your filters. Try clearing a filter.</p></article>';
     return;
   }
-
-  const implied = impliedProbability(pick.bookies_price);
-  const impliedText = Number.isFinite(implied) ? `${implied.toFixed(2)}%` : "—";
 
   dom.featuredSection.innerHTML = `
     <article class="featured-card">
       <div class="featured-top">
         <div>
-          <h2 class="fixture">${pick.home_team} vs ${pick.away_team}</h2>
-          <p class="result-tag">${pick.result}</p>
+          <h2 class="fixture">${row.home_team} vs ${row.away_team}</h2>
+          <p class="result-tag">${prettyResult(row.result)}</p>
         </div>
         <div>
-          <p class="value-big">${safeNumber(pick.value, 0).toFixed(2)}%</p>
-          <p class="money">${moneyTier(safeNumber(pick.value, 0))}</p>
+          <p class="value-big">${row.value.toFixed(2)}%</p>
+          <p class="money">${moneyTierIcons(row.value)}</p>
         </div>
       </div>
       <div class="featured-grid">
-        <div class="stat"><span>Model Price</span><strong>${safeNumber(pick.my_price, 0).toFixed(2)}</strong></div>
-        <div class="stat"><span>Bookie Price</span><strong>${safeNumber(pick.bookies_price, 0).toFixed(2)}</strong></div>
-        <div class="stat"><span>Model Probability</span><strong>${safeNumber(pick.my_probability, 0).toFixed(2)}%</strong></div>
-        <div class="stat"><span>Implied Probability</span><strong>${impliedText}</strong></div>
+        <div class="stat"><span>Model Price</span><strong>${row.my_price.toFixed(2)}</strong></div>
+        <div class="stat"><span>Bookie Price</span><strong>${row.bookies_price.toFixed(2)}</strong></div>
+        <div class="stat"><span>Value %</span><strong>${row.value.toFixed(2)}%</strong></div>
+        <div class="stat"><span>Model Probability</span><strong>${row.my_probability.toFixed(2)}%</strong></div>
+        <div class="stat"><span>Implied Probability</span><strong>${impliedProbability(row.bookies_price)}</strong></div>
       </div>
       <div style="margin-top: 10px;">
         <button id="featuredAddBtn" type="button" class="btn-primary">+ Shortlist</button>
@@ -421,92 +382,179 @@ function renderFeaturedPick(pick) {
     </article>
   `;
 
-  document.getElementById("featuredAddBtn").addEventListener("click", () => addToShortlist(pick));
+  const addBtn = document.getElementById("featuredAddBtn");
+  if (addBtn) addBtn.addEventListener("click", () => addToShortlist(row));
 }
 
-function fillList(node, picks) {
-  node.innerHTML = "";
-  if (!picks.length) {
-    node.innerHTML = '<p class="subtitle">No picks in this tier.</p>';
+function renderTierToggles(tier3Count, overflowCount) {
+  if (dom.tier3Toggle) dom.tier3Toggle.textContent = `▼ More Picks (${tier3Count})`;
+  if (dom.overflowToggle) dom.overflowToggle.textContent = `▼ Remaining Picks (${overflowCount})`;
+}
+
+function calculateCombinedOdds() {
+  return state.shortlist.reduce((acc, item) => {
+    const price = parseNumber(item.bookies_price);
+    return price > 0 ? acc * price : acc;
+  }, 1);
+}
+
+function saveShortlist() {
+  localStorage.setItem(SHORTLIST_KEY, JSON.stringify(state.shortlist));
+}
+
+function loadShortlist() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(SHORTLIST_KEY) || "[]");
+    state.shortlist = Array.isArray(parsed) ? parsed : [];
+  } catch (_error) {
+    state.shortlist = [];
+  }
+}
+
+function removeFromShortlist(id) {
+  state.shortlist = state.shortlist.filter((item) => item.id !== id);
+  saveShortlist();
+  renderShortlist();
+}
+
+function renderShortlist() {
+  const count = state.shortlist.length;
+  const odds = calculateCombinedOdds().toFixed(2);
+
+  if (dom.shortlistBar) dom.shortlistBar.classList.toggle("hidden", count === 0);
+  if (dom.shortlistCount) dom.shortlistCount.textContent = `${count} pick${count === 1 ? "" : "s"}`;
+  if (dom.shortlistOdds) dom.shortlistOdds.textContent = `Est. Odds: ${odds}`;
+  if (dom.modalOdds) dom.modalOdds.textContent = `Combined Odds: ${odds}`;
+
+  if (!dom.shortlistItems) return;
+
+  if (!count) {
+    dom.shortlistItems.innerHTML = '<p class="subtitle">No picks selected yet.</p>';
     return;
   }
-  picks.forEach((pick) => node.appendChild(createPickCard(pick)));
+
+  dom.shortlistItems.innerHTML = "";
+  state.shortlist.forEach((item) => {
+    const row = document.createElement("article");
+    row.className = "modal-item";
+    row.innerHTML = `
+      <div>
+        <p>${item.fixture}</p>
+        <p class="subtitle">${prettyResult(item.result)} @${formatOdds(item.bookies_price)}</p>
+      </div>
+      <button type="button" class="icon-btn" aria-label="Remove pick">✕</button>
+    `;
+
+    const removeBtn = row.querySelector("button");
+    if (removeBtn) removeBtn.addEventListener("click", () => removeFromShortlist(item.id));
+
+    dom.shortlistItems.appendChild(row);
+  });
 }
 
-function renderTiers(picks) {
-  const featuredExcluded = picks.slice(1);
-  const topVisible = featuredExcluded.slice(0, 10);
-  const overflow = featuredExcluded.slice(10);
-  const { tier1, tier2, tier3 } = splitIntoTiers(topVisible);
+function addToShortlist(row) {
+  const id = row.id || pickId(row);
+  if (state.shortlist.some((item) => item.id === id)) {
+    showStatus("Pick already in shortlist.");
+    return;
+  }
 
-  fillList(dom.tier1List, tier1);
-  fillList(dom.tier2List, tier2);
-  fillList(dom.tier3List, tier3);
-  fillList(dom.overflowList, overflow);
+  state.shortlist.push({
+    id,
+    fixture: `${row.home_team} vs ${row.away_team}`,
+    result: row.result,
+    bookies_price: row.bookies_price
+  });
 
-  dom.tier3Toggle.textContent = `▼ More Picks (${tier3.length})`;
-  dom.overflowToggle.textContent = `▼ Remaining Picks (${overflow.length})`;
+  saveShortlist();
+  renderShortlist();
+  showStatus("Added to shortlist.");
+}
+
+function clearShortlist() {
+  state.shortlist = [];
+  saveShortlist();
+  renderShortlist();
+  showStatus("Shortlist cleared.");
+}
+
+function copyShortlist() {
+  if (!state.shortlist.length) {
+    showStatus("No picks to copy.");
+    return;
+  }
+
+  const lines = state.shortlist.map((item) => `${item.fixture} - ${prettyResult(item.result)} @${formatOdds(item.bookies_price)}`);
+  lines.push(`Total Odds: ${calculateCombinedOdds().toFixed(2)}`);
+
+  navigator.clipboard.writeText(lines.join("\n"))
+    .then(() => showStatus("Picks copied."))
+    .catch(() => showStatus("Unable to copy picks."));
+}
+
+function attachStaticHandlers() {
+  if (dom.tier3Toggle && dom.tier3List) {
+    dom.tier3Toggle.addEventListener("click", () => {
+      const hidden = dom.tier3List.classList.toggle("hidden");
+      dom.tier3Toggle.setAttribute("aria-expanded", String(!hidden));
+    });
+  }
+
+  if (dom.overflowToggle && dom.overflowList) {
+    dom.overflowToggle.addEventListener("click", () => {
+      const hidden = dom.overflowList.classList.toggle("hidden");
+      dom.overflowToggle.setAttribute("aria-expanded", String(!hidden));
+    });
+  }
+
+  if (dom.viewShortlistBtn && dom.shortlistModal) {
+    dom.viewShortlistBtn.addEventListener("click", () => dom.shortlistModal.showModal());
+  }
+  if (dom.closeModalBtn && dom.shortlistModal) {
+    dom.closeModalBtn.addEventListener("click", () => dom.shortlistModal.close());
+  }
+  if (dom.clearPicksBtn) dom.clearPicksBtn.addEventListener("click", clearShortlist);
+  if (dom.copyPicksBtn) dom.copyPicksBtn.addEventListener("click", copyShortlist);
 }
 
 function render() {
-  if (loadState === "loading") {
+  if (state.loadState === "loading") {
     setLoadingState();
     return;
   }
 
-  if (loadState === "error") {
-    setErrorState();
+  if (state.loadState === "error") {
+    setFeedFailureState();
     return;
   }
 
-  const visiblePicks = applyFilters(allPicks);
-  console.log("Filtered row count before render:", visiblePicks.length);
+  const visibleRows = getVisibleRows();
 
-  if (!allPicks.length) {
-    dom.featuredSection.innerHTML = '<article class="featured-card"><p class="subtitle">Unable to load picks right now.</p></article>';
-    renderTiers([]);
+  if (!visibleRows.length) {
+    renderFeatured(null);
+    fillList(dom.tier1List, []);
+    fillList(dom.tier2List, []);
+    fillList(dom.tier3List, []);
+    fillList(dom.overflowList, []);
+    renderTierToggles(0, 0);
     return;
   }
 
-  if (!visiblePicks.length) {
-    renderFeaturedPick(null);
-    renderTiers([]);
-    return;
-  }
+  const { featured, tier1, tier2, tier3, overflow } = splitRowsForRendering(visibleRows);
 
-  renderFeaturedPick(visiblePicks[0]);
-  renderTiers(visiblePicks);
-}
-
-function attachStaticHandlers() {
-  dom.tier3Toggle.addEventListener("click", () => {
-    const isHidden = dom.tier3List.classList.toggle("hidden");
-    dom.tier3Toggle.setAttribute("aria-expanded", String(!isHidden));
-  });
-
-  dom.overflowToggle.addEventListener("click", () => {
-    const isHidden = dom.overflowList.classList.toggle("hidden");
-    dom.overflowToggle.setAttribute("aria-expanded", String(!isHidden));
-  });
-
-  dom.viewShortlistBtn.addEventListener("click", () => dom.shortlistModal.showModal());
-  dom.closeModalBtn.addEventListener("click", () => dom.shortlistModal.close());
-
-  dom.clearPicksBtn.addEventListener("click", () => {
-    shortlist = [];
-    persistShortlist();
-    updateShortlistUI();
-    setStatus("Shortlist cleared.");
-  });
-
-  dom.copyPicksBtn.addEventListener("click", copyPicks);
+  renderFeatured(featured);
+  fillList(dom.tier1List, tier1);
+  fillList(dom.tier2List, tier2);
+  fillList(dom.tier3List, tier3);
+  fillList(dom.overflowList, overflow);
+  renderTierToggles(tier3.length, overflow.length);
 }
 
 function init() {
-  buildFilters();
+  initFilters();
   attachStaticHandlers();
   loadShortlist();
-  updateShortlistUI();
+  renderShortlist();
   loadCsvData();
 }
 


### PR DESCRIPTION
### Motivation
- `/hda-value2/script.js` was replaced end-to-end because prior patch attempts left broken/fragile validation and the UI failing to render live CSV picks.
- Legacy header-validation logic and hardcoded error messages were removed so the app can accept header variations and surface feed or filter states without referencing "missing headers."
- The goal was to restore a working page driven by the provided CSV feed and to reimplement filtering, tiering, featured pick, and shortlist functionality cleanly.

### Description
- Rewrote the entire file to ingest the CSV with PapaParse using `download: true`, `header: true`, and `skipEmptyLines: true`, and added readable console logs for `Raw first row`, `Raw keys`, `First 5 normalised rows`, `Valid row count`, and filtered row counts. 
- Implemented robust header handling via `normaliseKey`, `buildKeyMap`, and `getField` plus `FIELD_ALIASES` to map varied header names to canonical fields, and `parseNumber` to safely parse numeric fields (stripping `%` and `,`).
- Built clean internal row objects with schema `{ id, date, day, league, home_team, away_team, result, my_probability, bookies_price, my_price, value }` and applied required-field filtering (skip rows missing home/away/result/bookies_price/value); rows are sorted by `value` desc and split into featured + Tier 1/2/3 and overflow with the first 10 visible picks shown. 
- Recreated UI wiring: filter pill behavior with default "show all" when no pills selected (case-insensitive matching for days and results), featured card (with implied probability calculation), compact list cards with tier money icons, and shortlist with `localStorage` persistence, duplicate prevention, remove/clear, combined odds multiplication, modal rendering, and `Copy Picks` output formatted as `Fixture - Result @Odds` plus total odds.

### Testing
- Confirmed legacy header-missing messages are removed by searching for the strings with `rg -n "Header row with required fields was not found|Failed to process feed: Header row with required fields was not found"` and the check passed (no matches). 
- Verified JavaScript syntax by running `node -e "new Function(require('fs').readFileSync('hda-value2/script.js','utf8')); console.log('syntax ok')"` which reported `syntax ok`.
- Performed a local commit verification (`git status`/commit) in the rollout environment to ensure the rewritten file is tracked; automated UI screenshots were not possible in this environment so visual confirmation was not captured by automated tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0d30704c832fb563483e6e3c4e45)