### PR TITLE
Add hidden /wc26 World Cup 2026 prediction page and Apps Script backend reference

### DIFF
--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -1,0 +1,53 @@
+# WC26 Submission Setup
+
+## Fixture CSV
+- The WC26 page loads fixtures client-side from this published CSV:
+  - https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=0&single=true&output=csv
+- To change fixture source, update `FIXTURES_CSV_URL` in `wc26.html`.
+
+## Google Sheet setup
+1. Create/open the target Google Sheet.
+2. Use tab name: `Predictions` (script auto-creates it if missing).
+3. Required headers (auto-created if tab is empty):
+   - submitted_at
+   - submission_id
+   - name
+   - email
+   - fixture_id
+   - sort_order
+   - match_date
+   - match_day_label
+   - kickoff_time
+   - group
+   - home_team
+   - home_team_code
+   - away_team
+   - away_team_code
+   - home_score
+   - away_score
+   - user_agent
+   - source_page
+
+## Apps Script deploy
+1. Create a new Apps Script project.
+2. Paste `apps-script/wc26-submit.gs` code.
+3. Set `SPREADSHEET_ID` to the target spreadsheet ID.
+4. Deploy as **Web App**:
+   - Execute as: **Me (owner)**
+   - Access: **Anyone** or **Anyone with the link**
+5. Authorize permissions:
+   - Spreadsheet access
+   - Email sending (MailApp)
+6. Copy deployed Web App URL and paste into `SUBMISSION_ENDPOINT` in `wc26.html`.
+
+## Testing submissions
+1. Open `/wc26` and ensure 72 fixtures load.
+2. Fill name, email, consent, and all scores.
+3. Submit and verify success message + submission ID.
+4. Confirm 72 rows appended in `Predictions`.
+5. Confirm entrant email contains grouped predictions.
+
+## Resubmissions
+- Multiple submissions are allowed.
+- Each submission writes 72 new rows with its own `submission_id`.
+- Later scoring should select latest valid submission before deadline per email address.

--- a/apps-script/wc26-submit.gs
+++ b/apps-script/wc26-submit.gs
@@ -1,0 +1,110 @@
+const SPREADSHEET_ID = "PASTE_TARGET_SPREADSHEET_ID_HERE";
+const PREDICTIONS_SHEET_NAME = "Predictions";
+const DEADLINE_LONDON_ISO = "2026-06-10T23:59:00+01:00";
+const REQUIRED_FIXTURE_COUNT = 72;
+
+function doPost(e) {
+  try {
+    const payload = JSON.parse((e && e.postData && e.postData.contents) || "{}");
+    const validationError = validatePayload_(payload);
+    if (validationError) return jsonOutput_({ ok: false, error: validationError });
+
+    const submissionId = isValidSubmissionId_(payload.submission_id) ? payload.submission_id : generateSubmissionId_();
+    const submittedAt = new Date().toISOString();
+    const sheet = getOrCreatePredictionsSheet_();
+
+    const rows = payload.predictions.map((p) => [
+      submittedAt,
+      submissionId,
+      payload.name.trim(),
+      payload.email.trim().toLowerCase(),
+      String(p.fixture_id),
+      Number(p.sort_order),
+      p.match_date,
+      p.match_day_label,
+      p.kickoff_time || "",
+      p.group,
+      p.home_team,
+      p.home_team_code || "",
+      p.away_team,
+      p.away_team_code || "",
+      Number(p.home_score),
+      Number(p.away_score),
+      payload.user_agent || "",
+      payload.source_page || ""
+    ]);
+    sheet.getRange(sheet.getLastRow() + 1, 1, rows.length, rows[0].length).setValues(rows);
+
+    sendConfirmationEmail_(payload.name, payload.email, submissionId, payload.predictions);
+    return jsonOutput_({ ok: true, submission_id: submissionId, message: "Predictions submitted successfully." });
+  } catch (error) {
+    return jsonOutput_({ ok: false, error: "Unexpected server error. Please try again." });
+  }
+}
+
+function validatePayload_(payload) {
+  if (!payload || typeof payload !== "object") return "Missing submission payload.";
+  if ((payload.website || "").trim() !== "") return "Submission blocked by spam protection.";
+  if (!payload.name || !payload.name.trim()) return "Name is required.";
+  if (!payload.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(payload.email)) return "Valid email is required.";
+  if (payload.consent_given !== true) return "Consent checkbox must be confirmed.";
+  if (Date.now() > new Date(DEADLINE_LONDON_ISO).getTime()) return "Entries are now closed.";
+  if (!Array.isArray(payload.predictions)) return "Predictions array is required.";
+  if (payload.predictions.length !== REQUIRED_FIXTURE_COUNT) return "Exactly 72 predictions are required.";
+
+  for (var i = 0; i < payload.predictions.length; i++) {
+    var p = payload.predictions[i];
+    if (!p.fixture_id || p.sort_order === undefined || !p.match_date || !p.match_day_label || !p.group || !p.home_team || !p.away_team) {
+      return "One or more predictions are missing required fixture fields.";
+    }
+    if (!Number.isInteger(Number(p.home_score)) || !Number.isInteger(Number(p.away_score))) return "Scores must be integers.";
+    if (Number(p.home_score) < 0 || Number(p.home_score) > 9 || Number(p.away_score) < 0 || Number(p.away_score) > 9) {
+      return "Scores must be between 0 and 9.";
+    }
+  }
+  return "";
+}
+
+function getOrCreatePredictionsSheet_() {
+  const ss = SpreadsheetApp.openById(SPREADSHEET_ID);
+  let sheet = ss.getSheetByName(PREDICTIONS_SHEET_NAME);
+  if (!sheet) sheet = ss.insertSheet(PREDICTIONS_SHEET_NAME);
+
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow([
+      "submitted_at","submission_id","name","email","fixture_id","sort_order","match_date","match_day_label","kickoff_time","group","home_team","home_team_code","away_team","away_team_code","home_score","away_score","user_agent","source_page"
+    ]);
+  }
+  return sheet;
+}
+
+function sendConfirmationEmail_(name, email, submissionId, predictions) {
+  const byDay = {};
+  predictions.forEach(function(p) {
+    if (!byDay[p.match_day_label]) byDay[p.match_day_label] = [];
+    byDay[p.match_day_label].push(p);
+  });
+
+  let body = `Hi ${name},\n\nThanks for submitting your World Cup 2026 predictions.\n\nYour submission ID is: ${submissionId}\n\nIf you submit again before Wednesday 10th June 2026 at 11:59pm UK time, your latest valid submission will be used.\n\nYour predictions:\n`;
+  Object.keys(byDay).forEach(function(day) {
+    body += `\n${day}\n`;
+    byDay[day].forEach(function(p) {
+      body += `${p.group}\n${p.home_team} ${p.home_score}-${p.away_score} ${p.away_team}\n`;
+    });
+  });
+  body += "\nGood luck,\nMC Predict";
+
+  MailApp.sendEmail(email, "Your MC Predict World Cup 2026 predictions", body);
+}
+
+function jsonOutput_(obj) {
+  return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
+}
+
+function isValidSubmissionId_(v) {
+  return typeof v === "string" && /^SUB-[A-Z0-9]{6,12}$/.test(v);
+}
+
+function generateSubmissionId_() {
+  return "SUB-" + Math.random().toString(36).slice(2, 8).toUpperCase();
+}

--- a/wc26.html
+++ b/wc26.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MC Predict | World Cup 2026 Predictions</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    :root {
+      --bg: #161618;
+      --panel: #222326;
+      --panel-2: #2b2c30;
+      --text: #f4f4f4;
+      --muted: #b6b8c0;
+      --accent-green: #3CAC3B;
+      --accent-blue: #2A398D;
+      --accent-red: #E61D25;
+      --border: rgba(255,255,255,.12);
+      --danger: #ff7f7f;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: 'Proxima Nova', Arial, sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at top, #2a2c33 0%, #1b1c20 42%, #111214 100%);
+    }
+    .wc26-page {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 16px 14px 80px;
+    }
+    .hero, .card {
+      background: linear-gradient(145deg, rgba(48,49,56,.95), rgba(28,29,33,.95));
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: 0 14px 30px rgba(0,0,0,.35);
+    }
+    .hero { padding: 18px; margin-bottom: 14px; }
+    .title { margin: 0; font-size: 1.35rem; }
+    .subtitle { margin: 8px 0 0; color: var(--muted); line-height: 1.5; }
+    .note { margin-top: 10px; font-size: .95rem; color: #d8e2ff; }
+    .card { padding: 16px; margin-bottom: 12px; }
+    label { display:block; font-weight:600; margin-bottom:6px; }
+    input[type="text"], input[type="email"] {
+      width: 100%; padding: 11px 12px; border-radius: 10px;
+      border: 1px solid var(--border); background: var(--panel-2); color: var(--text);
+    }
+    .row { margin-bottom: 12px; }
+    .consent-row { display:flex; gap:10px; align-items:flex-start; }
+    .consent-row input { margin-top: 4px; }
+    .hidden-hp { position: absolute; left: -10000px; top: auto; width: 1px; height: 1px; overflow: hidden; }
+    .status, .error, .success, .warning { border-radius: 10px; padding: 10px 12px; margin-bottom: 10px; }
+    .status { background: rgba(42,57,141,.2); border:1px solid rgba(42,57,141,.6); }
+    .warning { background: rgba(230,29,37,.18); border:1px solid rgba(230,29,37,.6); }
+    .error { background: rgba(255,70,70,.14); border:1px solid rgba(255,90,90,.7); }
+    .success { background: rgba(60,172,59,.15); border:1px solid rgba(60,172,59,.7); }
+    .fixtures-day { margin: 16px 0 8px; padding-bottom: 4px; border-bottom: 1px solid rgba(255,255,255,.1); }
+    .fixtures-day h3 { margin: 0; font-size: 1rem; color: #e9efff; }
+    .fixture {
+      display: grid;
+      grid-template-columns: 1fr auto auto auto 1fr;
+      gap: 8px;
+      align-items: center;
+      background: rgba(255,255,255,.04);
+      border: 1px solid rgba(255,255,255,.08);
+      border-radius: 12px;
+      padding: 10px;
+      margin-bottom: 8px;
+    }
+    .group-label { grid-column: 1 / -1; font-size: .74rem; text-transform: uppercase; color: #9ec3ff; letter-spacing: .08em; }
+    .team-home, .team-away { font-size: .92rem; }
+    .team-away { text-align: right; }
+    .score-input {
+      width: 42px; height: 42px; text-align:center; font-size: 1.1rem;
+      border-radius: 10px; border: 1px solid rgba(255,255,255,.25);
+      background: #141519; color: #fff;
+    }
+    .score-sep { color: var(--muted); font-weight: 700; }
+    .actions { position: sticky; bottom: 0; background: rgba(17,18,20,.95); backdrop-filter: blur(6px); padding-top: 8px; }
+    button {
+      width: 100%; border: 0; border-radius: 12px; padding: 12px 14px;
+      font-weight: 700; font-size: 1rem; cursor: pointer;
+    }
+    #submitBtn { background: linear-gradient(135deg, var(--accent-green), #69d768); color: #111; }
+    #submitBtn:disabled { background: #666; color: #ccc; cursor:not-allowed; }
+    .secondary-btn { margin-top: 8px; background: #2f3140; color: #fff; border:1px solid var(--border); }
+    :focus-visible { outline: 2px solid #7bb1ff; outline-offset: 2px; }
+    @media (max-width: 560px) {
+      .fixture { grid-template-columns: 1fr 42px auto 42px 1fr; }
+      .team-home, .team-away { font-size: .84rem; }
+    }
+  </style>
+</head>
+<body>
+  <main class="wc26-page">
+    <section class="hero">
+      <h1 class="title">World Cup 2026 Group Stage Predictions</h1>
+      <p class="subtitle">Submit your correct score predictions for all 72 group-stage fixtures.</p>
+      <p class="note" id="deadlineNote">Entries close at 11:59pm UK time on Wednesday 10th June 2026.</p>
+      <p class="note">Multiple submissions are allowed, but only your latest valid submission before the deadline will be used.</p>
+    </section>
+
+    <form id="wc26Form" novalidate>
+      <section class="card">
+        <div id="globalMessages" aria-live="polite"></div>
+        <div class="row">
+          <label for="nameInput">Name</label>
+          <input id="nameInput" name="name" type="text" required autocomplete="name" />
+        </div>
+        <div class="row">
+          <label for="emailInput">Email address</label>
+          <input id="emailInput" name="email" type="email" required autocomplete="email" />
+        </div>
+        <div class="row consent-row">
+          <input id="consentInput" name="consent" type="checkbox" required />
+          <label for="consentInput">I agree for MC Predict to store my name, email and predictions for the purpose of running this game.</label>
+        </div>
+        <div class="hidden-hp" aria-hidden="true">
+          <label for="websiteInput">Website</label>
+          <input id="websiteInput" name="website" type="text" tabindex="-1" autocomplete="off" />
+        </div>
+      </section>
+
+      <section class="card">
+        <div class="status" id="progressText">0 / 72 predictions completed</div>
+        <div id="fixtureWarnings"></div>
+        <div id="fixturesContainer"></div>
+      </section>
+
+      <section class="actions">
+        <button type="submit" id="submitBtn" disabled>Submit predictions</button>
+        <button type="button" class="secondary-btn" id="clearBtn">Clear saved predictions</button>
+      </section>
+    </form>
+  </main>
+
+  <script>
+    const FIXTURES_CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=0&single=true&output=csv";
+    const SUBMISSION_ENDPOINT = "PASTE_APPS_SCRIPT_WEB_APP_URL_HERE";
+    const LOCAL_STORAGE_KEY = "mcpredict:wc26:prediction-form";
+    const REQUIRED_FIXTURE_COUNT = 72;
+    const DEADLINE_ISO_LONDON = "2026-06-10T23:59:00+01:00";
+
+    const form = document.getElementById('wc26Form');
+    const nameInput = document.getElementById('nameInput');
+    const emailInput = document.getElementById('emailInput');
+    const consentInput = document.getElementById('consentInput');
+    const websiteInput = document.getElementById('websiteInput');
+    const fixturesContainer = document.getElementById('fixturesContainer');
+    const progressText = document.getElementById('progressText');
+    const globalMessages = document.getElementById('globalMessages');
+    const fixtureWarnings = document.getElementById('fixtureWarnings');
+    const submitBtn = document.getElementById('submitBtn');
+
+    let fixtures = [];
+    let scoreInputs = [];
+    let submitting = false;
+
+    const parseCsv = (text) => {
+      const lines = text.trim().split(/\r?\n/);
+      const headers = lines.shift().split(',').map(h => h.trim());
+      return lines.map(line => {
+        const cols = line.split(',');
+        const row = {};
+        headers.forEach((h, i) => row[h] = (cols[i] || '').trim());
+        return row;
+      });
+    };
+
+    const isClosed = () => Date.now() > new Date(DEADLINE_ISO_LONDON).getTime();
+    const validEmail = v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v.trim());
+    const generateSubmissionId = () => `SUB-${Math.random().toString(36).slice(2,8).toUpperCase()}`;
+
+    function renderMessage(type, text, target = globalMessages) {
+      target.innerHTML = `<div class="${type}">${text}</div>`;
+    }
+
+    function saveLocal() {
+      const predictions = {};
+      scoreInputs.forEach(input => { predictions[input.dataset.key] = input.value; });
+      const payload = { name: nameInput.value, email: emailInput.value, consent: consentInput.checked, predictions };
+      localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(payload));
+    }
+
+    function restoreLocal() {
+      try {
+        const raw = localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (!raw) return;
+        const data = JSON.parse(raw);
+        nameInput.value = data.name || '';
+        emailInput.value = data.email || '';
+        consentInput.checked = Boolean(data.consent);
+        scoreInputs.forEach(input => input.value = data.predictions?.[input.dataset.key] || '');
+      } catch (e) { console.warn('Restore failed', e); }
+    }
+
+    function completedCount() {
+      let c = 0;
+      for (let i = 0; i < fixtures.length; i++) {
+        const h = document.querySelector(`[data-key="${fixtures[i].fixture_id}:home"]`)?.value;
+        const a = document.querySelector(`[data-key="${fixtures[i].fixture_id}:away"]`)?.value;
+        if (h !== '' && a !== '') c++;
+      }
+      return c;
+    }
+
+    function validate(show = false) {
+      const errs = [];
+      if (!fixtures.length) errs.push('Fixtures are still loading.');
+      if (fixtures.length && fixtures.length !== REQUIRED_FIXTURE_COUNT) errs.push(`Expected 72 fixtures but loaded ${fixtures.length}.`);
+      if (!nameInput.value.trim()) errs.push('Please enter your name.');
+      if (!validEmail(emailInput.value)) errs.push('Please enter a valid email address.');
+      if (!consentInput.checked) errs.push('Please confirm the consent checkbox before submitting.');
+      if (websiteInput.value.trim()) errs.push('Spam check failed. Please refresh and try again.');
+      if (completedCount() !== REQUIRED_FIXTURE_COUNT) errs.push('Please complete all 72 predictions before submitting.');
+      if (isClosed()) errs.push('Entries are now closed for the MC Predict World Cup 2026 prediction game.');
+
+      if (show && errs.length) renderMessage('error', errs[0]);
+      submitBtn.disabled = errs.length > 0 || submitting;
+      progressText.textContent = `${completedCount()} / ${REQUIRED_FIXTURE_COUNT} predictions completed`;
+      return errs;
+    }
+
+    function attachScoreBehavior() {
+      scoreInputs = Array.from(document.querySelectorAll('.score-input'));
+      scoreInputs.forEach((input, idx) => {
+        input.addEventListener('input', () => {
+          input.value = input.value.replace(/[^0-9]/g, '').slice(0, 1);
+          if (input.value && scoreInputs[idx + 1]) scoreInputs[idx + 1].focus();
+          saveLocal();
+          validate();
+        });
+        input.addEventListener('keydown', (e) => {
+          if (e.key === 'Backspace' && !input.value && scoreInputs[idx - 1]) {
+            scoreInputs[idx - 1].focus();
+          }
+        });
+      });
+    }
+
+    async function loadFixtures() {
+      try {
+        const resp = await fetch(FIXTURES_CSV_URL);
+        if (!resp.ok) throw new Error(`CSV fetch failed: ${resp.status}`);
+        const data = parseCsv(await resp.text());
+        const required = ['fixture_id','sort_order','match_date','match_day_label','kickoff_time','group','home_team','home_team_code','home_flag','away_team','away_team_code','away_flag'];
+        const missing = required.filter(k => !(k in data[0]));
+        if (missing.length) throw new Error(`Missing columns: ${missing.join(', ')}`);
+        fixtures = data.sort((a,b) => Number(a.sort_order) - Number(b.sort_order));
+
+        if (fixtures.length !== REQUIRED_FIXTURE_COUNT) {
+          renderMessage('warning', `Fixture count warning: ${fixtures.length} loaded (expected 72).`, fixtureWarnings);
+        }
+
+        let currentDay = '';
+        fixturesContainer.innerHTML = '';
+        fixtures.forEach((fx) => {
+          if (fx.match_day_label !== currentDay) {
+            currentDay = fx.match_day_label;
+            fixturesContainer.insertAdjacentHTML('beforeend', `<div class="fixtures-day"><h3>${currentDay}</h3></div>`);
+          }
+          fixturesContainer.insertAdjacentHTML('beforeend', `
+            <article class="fixture">
+              <div class="group-label">${fx.group} • ${fx.kickoff_time}</div>
+              <div class="team-home">${fx.home_team} ${fx.home_flag}</div>
+              <input class="score-input" data-key="${fx.fixture_id}:home" inputmode="numeric" maxlength="1" aria-label="${fx.home_team} score against ${fx.away_team}" ${isClosed() ? 'disabled' : ''}>
+              <span class="score-sep">-</span>
+              <input class="score-input" data-key="${fx.fixture_id}:away" inputmode="numeric" maxlength="1" aria-label="${fx.away_team} score against ${fx.home_team}" ${isClosed() ? 'disabled' : ''}>
+              <div class="team-away">${fx.away_flag} ${fx.away_team}</div>
+            </article>
+          `);
+        });
+        attachScoreBehavior();
+        restoreLocal();
+        validate();
+      } catch (error) {
+        console.error(error);
+        renderMessage('error', 'We could not load fixtures right now. Please try again shortly.');
+      }
+    }
+
+    form.addEventListener('input', () => { saveLocal(); validate(); });
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const errs = validate(true);
+      if (errs.length) return;
+      if (SUBMISSION_ENDPOINT.includes('PASTE_APPS_SCRIPT')) {
+        renderMessage('error', 'Submission endpoint is not configured yet. Please try again later.');
+        return;
+      }
+      submitting = true;
+      validate();
+
+      const submissionId = generateSubmissionId();
+      const predictions = fixtures.map(fx => ({
+        ...fx,
+        sort_order: Number(fx.sort_order),
+        home_score: Number(document.querySelector(`[data-key="${fx.fixture_id}:home"]`).value),
+        away_score: Number(document.querySelector(`[data-key="${fx.fixture_id}:away"]`).value)
+      }));
+      const body = {
+        submission_id: submissionId,
+        submitted_at_client: new Date().toISOString(),
+        name: nameInput.value.trim(),
+        email: emailInput.value.trim(),
+        consent_given: consentInput.checked,
+        website: websiteInput.value,
+        source_page: '/wc26',
+        user_agent: navigator.userAgent,
+        predictions
+      };
+
+      try {
+        const resp = await fetch(SUBMISSION_ENDPOINT, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
+        const data = await resp.json();
+        if (!resp.ok || !data.ok) throw new Error(data.error || 'Submission failed');
+        renderMessage('success', `Predictions submitted successfully. Your submission ID is ${data.submission_id}. We’ve emailed you a copy of your predictions. If you submit again before the deadline, your latest valid submission will be used. Your saved predictions remain on this device in case you want to amend and submit again before the deadline.`);
+      } catch (error) {
+        console.error(error);
+        renderMessage('error', `Unable to submit predictions right now. ${error.message}`);
+      } finally {
+        submitting = false;
+        validate();
+      }
+    });
+
+    document.getElementById('clearBtn').addEventListener('click', () => {
+      if (!confirm('Clear saved predictions from this device?')) return;
+      localStorage.removeItem(LOCAL_STORAGE_KEY);
+      form.reset();
+      scoreInputs.forEach(i => i.value = '');
+      validate();
+      renderMessage('status', 'Saved predictions cleared from this device.');
+    });
+
+    if (isClosed()) {
+      document.getElementById('deadlineNote').textContent = 'Entries are now closed for the MC Predict World Cup 2026 prediction game.';
+      renderMessage('warning', 'Entries are now closed for the MC Predict World Cup 2026 prediction game.');
+    }
+
+    loadFixtures();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a hidden, mobile-first MC Predict page at `/wc26` that accepts full correct-score predictions for all 72 World Cup 2026 group-stage fixtures.  
- Persist user progress locally and submit validated predictions to Google Sheets via a Google Apps Script backend while enforcing deadline, consent and anti-spam rules.  
- Keep the page stylistically consistent with the existing dark MC Predict theme and ensure the flow is usable on mobile and keyboard-only navigation.

### Description
- Added `wc26.html`, a standalone hidden page that loads fixtures from the provided CSV (`FIXTURES_CSV_URL`), renders day/group headings and 72 fixture cards, provides two one-digit score inputs per fixture with `inputmode="numeric"` and `maxlength="1"`, auto-advance/backspace navigation, progress indicator, and localStorage persistence under `mcpredict:wc26:prediction-form`.  
- Implemented client-side validation for name, email, consent (exact text), honeypot `website`, fixtures count (expects exactly 72), deadline gating (`DEADLINE_ISO_LONDON`), and submit-button enable/disable logic, and built the JSON submission payload with numeric scores and a client `submission_id`.  
- Added `apps-script/wc26-submit.gs` as a reference Apps Script backend implementing `doPost(e)`, full server-side validation (honeypot, email, consent, deadline, exactly 72 predictions, score bounds), automatic creation/initialisation of a `Predictions` sheet and header row, appending 72 rows per submission, confirmation email generation (grouped by match day), and JSON success/error responses.  
- Added `apps-script/README.md` with deployment and configuration instructions (how to set `SPREADSHEET_ID`, deploy the Web App, paste the deployed URL into `SUBMISSION_ENDPOINT`, fixture CSV notes and testing/resubmission guidance), and left the page unlinked from site navigation as requested.

### Testing
- Ran repository operations `git status --short`, added files and committed successfully with `git commit`, and created the PR, all of which completed without errors.  
- Performed a basic static review of the generated files and configuration constants (no automated unit tests exist in this repo for the new flow).  
- No automated browser/endpoint integration tests were executed in this CLI environment; a manual checklist for live testing is included in `apps-script/README.md` and should be run in a browser against a deployed Apps Script endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4f00067c832f8bfb11c4b438388a)