### PR TITLE
Fix WC26 Apps Script health check and static-site submission handling

### DIFF
--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -41,11 +41,18 @@
 6. Copy deployed Web App URL and paste into `SUBMISSION_ENDPOINT` in `wc26.html`.
 
 ## Testing submissions
-1. Open `/wc26` and ensure 72 fixtures load.
-2. Fill name, email, consent, and all scores.
-3. Submit and verify success message + submission ID.
-4. Confirm 72 rows appended in `Predictions`.
-5. Confirm entrant email contains grouped predictions.
+1. Open the deployed Web App URL directly and confirm the `doGet` health-check JSON appears.
+2. Open `/wc26` and ensure 72 fixtures load.
+3. Fill name, email, consent, and all scores.
+4. Submit and verify submitted message + submission ID.
+5. Confirm 72 rows appended in `Predictions`.
+6. Confirm entrant email contains grouped predictions.
+
+## Implementation notes
+- Opening the Web App URL directly should show the `doGet` health check response.
+- Real submissions use `POST` from `/wc26`.
+- The browser cannot read the Apps Script JSON response when using `no-cors`.
+- The confirmation email and `Predictions` tab are the source of truth for successful submissions.
 
 ## Resubmissions
 - Multiple submissions are allowed.

--- a/apps-script/wc26-submit.gs
+++ b/apps-script/wc26-submit.gs
@@ -3,9 +3,18 @@ const PREDICTIONS_SHEET_NAME = "Predictions";
 const DEADLINE_LONDON_ISO = "2026-06-10T23:59:00+01:00";
 const REQUIRED_FIXTURE_COUNT = 72;
 
+function doGet(e) {
+  return jsonOutput_({
+    ok: true,
+    service: "MC Predict WC26 submission endpoint",
+    message: "Endpoint is live. Use POST to submit predictions."
+  });
+}
+
 function doPost(e) {
   try {
-    const payload = JSON.parse((e && e.postData && e.postData.contents) || "{}");
+    const rawBody = (e && e.postData && typeof e.postData.contents === "string") ? e.postData.contents : "{}";
+    const payload = JSON.parse(rawBody || "{}");
     const validationError = validatePayload_(payload);
     if (validationError) return jsonOutput_({ ok: false, error: validationError });
 

--- a/wc26.html
+++ b/wc26.html
@@ -313,13 +313,17 @@
       };
 
       try {
-        const resp = await fetch(SUBMISSION_ENDPOINT, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
-        const data = await resp.json();
-        if (!resp.ok || !data.ok) throw new Error(data.error || 'Submission failed');
-        renderMessage('success', `Predictions submitted successfully. Your submission ID is ${data.submission_id}. We’ve emailed you a copy of your predictions. If you submit again before the deadline, your latest valid submission will be used. Your saved predictions remain on this device in case you want to amend and submit again before the deadline.`);
+        // Google Apps Script Web Apps do not return browser-readable CORS responses for this static-site flow,
+        // so we submit with no-cors and treat a completed fetch as a successful handoff.
+        await fetch(SUBMISSION_ENDPOINT, {
+          method: 'POST',
+          mode: 'no-cors',
+          body: JSON.stringify(body)
+        });
+        renderMessage('success', `Predictions submitted. Your submission ID is ${submissionId}. Please check your email for confirmation. If you do not receive an email, contact MC Predict.`);
       } catch (error) {
-        console.error(error);
-        renderMessage('error', `Unable to submit predictions right now. ${error.message}`);
+        console.error('WC26 submission failed:', error);
+        renderMessage('error', 'Unable to submit predictions right now. Please check your connection and try again.');
       } finally {
         submitting = false;
         validate();


### PR DESCRIPTION
### Motivation
- Browsers were reporting `Failed to fetch` and the Apps Script deployment returned `Script function not found: doGet` when opening the Web App URL, so the endpoint needed a health-check and the frontend had to be adapted for static-site -> Apps Script CORS limitations.
- The change must preserve all existing server-side validation, storage, and confirmation email behavior while making client submission reliable from a static site.

### Description
- Added a `doGet(e)` health-check to `apps-script/wc26-submit.gs` which returns JSON `{ ok: true, service: "MC Predict WC26 submission endpoint", message: "Endpoint is live. Use POST to submit predictions." }`.
- Updated `doPost(e)` to parse JSON from `e.postData.contents` using a robust `rawBody` read so it does not rely on `Content-Type` headers, while keeping all existing validation and behavior (honeypot, name/email/consent/deadline checks, exactly 72 predictions, integer scores 0–9, appending 72 rows to `Predictions`, and sending confirmation email).
- Updated the `/wc26` frontend (`wc26.html`) to submit with `fetch(SUBMISSION_ENDPOINT, { method: 'POST', mode: 'no-cors', body: JSON.stringify(body) })`, removed custom `Content-Type` header and response `.json()` parsing, added an explanatory comment about `no-cors`, and display the requested success/error messages based on completed fetch and the client-generated `submissionId`.
- Updated `apps-script/README.md` with testing steps and implementation notes explaining the `doGet` health-check, `no-cors` opaque-response limitation, and that the confirmation email and `Predictions` sheet are the source of truth.

### Testing
- Inspected and updated files using repository queries and file prints (`rg`, `sed`, `nl`) to validate diffs and content; these inspection steps completed successfully.
- Verified the code diff and committed changes (`git diff`, `git commit`) and created PR metadata via the local `make_pr` helper; the commit and PR metadata creation succeeded.
- Printed the modified files (`nl -ba apps-script/wc26-submit.gs`, `nl -ba wc26.html`, `nl -ba apps-script/README.md`) to confirm the edits are present; these checks succeeded.
- End-to-end redeploy and live browser/Sheets/email verification were not executed in this environment and remain to be run in the deployed Google Apps Script/production environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4339fe0c832faa40b7427380ed04)