### PR TITLE
Enhance /wc26 submission UX with success modal and submit-area error messaging

### DIFF
--- a/wc26.html
+++ b/wc26.html
@@ -79,6 +79,52 @@
     }
     .score-sep { color: var(--muted); font-weight: 700; }
     .actions { position: sticky; bottom: 0; background: rgba(17,18,20,.95); backdrop-filter: blur(6px); padding-top: 8px; }
+    #submitErrorArea { margin-bottom: 8px; }
+    #submitErrorArea:empty { display: none; }
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(8, 9, 12, 0.78);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+      z-index: 1000;
+    }
+    .modal-overlay.open { display: flex; }
+    .success-modal {
+      width: 100%;
+      max-width: 460px;
+      border-radius: 16px;
+      border: 1px solid rgba(255,255,255,.14);
+      background: linear-gradient(145deg, rgba(48,49,56,.98), rgba(22,23,28,.98));
+      box-shadow: 0 16px 40px rgba(0,0,0,.45);
+      padding: 18px;
+    }
+    .success-modal h2 { margin: 0 0 10px; font-size: 1.25rem; color: #f3f6ff; }
+    .success-modal p { margin: 0 0 12px; line-height: 1.5; color: #dce2f7; }
+    .submission-id {
+      display: inline-block;
+      font-weight: 800;
+      color: #fff;
+      padding: 4px 8px;
+      border-radius: 8px;
+      background: linear-gradient(135deg, rgba(60,172,59,.28), rgba(42,57,141,.28));
+      border: 1px solid rgba(60,172,59,.6);
+    }
+    .modal-cta { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 14px; }
+    .pay-btn {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      text-decoration: none;
+      border-radius: 12px;
+      font-weight: 700;
+      padding: 12px 14px;
+      color: #fff;
+      background: linear-gradient(135deg, var(--accent-blue), var(--accent-red));
+      border: 1px solid rgba(255,255,255,.14);
+    }
     button {
       width: 100%; border: 0; border-radius: 12px; padding: 12px 14px;
       font-weight: 700; font-size: 1rem; cursor: pointer;
@@ -130,11 +176,24 @@
       </section>
 
       <section class="actions">
+        <div id="submitErrorArea" aria-live="polite"></div>
         <button type="submit" id="submitBtn" disabled>Submit predictions</button>
         <button type="button" class="secondary-btn" id="clearBtn">Clear saved predictions</button>
       </section>
     </form>
   </main>
+  <div class="modal-overlay" id="successModalOverlay">
+    <div class="success-modal" role="dialog" aria-modal="true" aria-labelledby="successModalTitle">
+      <h2 id="successModalTitle">Predictions submitted!</h2>
+      <p>Your submission ID is <span class="submission-id" id="modalSubmissionId"></span>.</p>
+      <p>Please check your email for confirmation. If you do not receive an email, contact MC Predict.</p>
+      <p>Please pay the entry fee to validate your entry.</p>
+      <div class="modal-cta">
+        <a id="payNowBtn" class="pay-btn" href="https://paypal.me/statmatt14" target="_blank" rel="noopener noreferrer">Pay Now</a>
+        <button type="button" class="secondary-btn" id="continueBtn">Continue</button>
+      </div>
+    </div>
+  </div>
 
   <script>
     const FIXTURES_CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=0&single=true&output=csv";
@@ -153,6 +212,10 @@
     const globalMessages = document.getElementById('globalMessages');
     const fixtureWarnings = document.getElementById('fixtureWarnings');
     const submitBtn = document.getElementById('submitBtn');
+    const submitErrorArea = document.getElementById('submitErrorArea');
+    const successModalOverlay = document.getElementById('successModalOverlay');
+    const modalSubmissionId = document.getElementById('modalSubmissionId');
+    const continueBtn = document.getElementById('continueBtn');
 
     let fixtures = [];
     let scoreInputs = [];
@@ -176,6 +239,15 @@
     function renderMessage(type, text, target = globalMessages) {
       target.innerHTML = `<div class="${type}">${text}</div>`;
     }
+    function clearMessage(target = globalMessages) { target.innerHTML = ''; }
+    function showSubmitError(text) { renderMessage('error', text, submitErrorArea); }
+    function clearSubmitError() { clearMessage(submitErrorArea); }
+    function openSuccessModal(submissionId) {
+      modalSubmissionId.textContent = submissionId;
+      successModalOverlay.classList.add('open');
+      continueBtn.focus();
+    }
+    function closeSuccessModal() { successModalOverlay.classList.remove('open'); }
 
     function saveLocal() {
       const predictions = {};
@@ -217,7 +289,8 @@
       if (completedCount() !== REQUIRED_FIXTURE_COUNT) errs.push('Please complete all 72 predictions before submitting.');
       if (isClosed()) errs.push('Entries are now closed for the MC Predict World Cup 2026 prediction game.');
 
-      if (show && errs.length) renderMessage('error', errs[0]);
+      if (show && errs.length) showSubmitError(errs[0]);
+      if (!errs.length) clearSubmitError();
       submitBtn.disabled = errs.length > 0 || submitting;
       progressText.textContent = `${completedCount()} / ${REQUIRED_FIXTURE_COUNT} predictions completed`;
       return errs;
@@ -278,6 +351,7 @@
       } catch (error) {
         console.error(error);
         renderMessage('error', 'We could not load fixtures right now. Please try again shortly.');
+        showSubmitError('Fixtures are still loading.');
       }
     }
 
@@ -287,7 +361,7 @@
       const errs = validate(true);
       if (errs.length) return;
       if (SUBMISSION_ENDPOINT.includes('PASTE_APPS_SCRIPT')) {
-        renderMessage('error', 'Submission endpoint is not configured yet. Please try again later.');
+        showSubmitError('Submission endpoint is not configured yet. Please try again later.');
         return;
       }
       submitting = true;
@@ -320,10 +394,11 @@
           mode: 'no-cors',
           body: JSON.stringify(body)
         });
-        renderMessage('success', `Predictions submitted. Your submission ID is ${submissionId}. Please check your email for confirmation. If you do not receive an email, contact MC Predict.`);
+        clearSubmitError();
+        openSuccessModal(submissionId);
       } catch (error) {
         console.error('WC26 submission failed:', error);
-        renderMessage('error', 'Unable to submit predictions right now. Please check your connection and try again.');
+        showSubmitError('Unable to submit predictions right now. Please check your connection and try again.');
       } finally {
         submitting = false;
         validate();
@@ -343,6 +418,10 @@
       document.getElementById('deadlineNote').textContent = 'Entries are now closed for the MC Predict World Cup 2026 prediction game.';
       renderMessage('warning', 'Entries are now closed for the MC Predict World Cup 2026 prediction game.');
     }
+    continueBtn.addEventListener('click', closeSuccessModal);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && successModalOverlay.classList.contains('open')) closeSuccessModal();
+    });
 
     loadFixtures();
   </script>


### PR DESCRIPTION
### Motivation
- Replace the inline success banner with a premium, mobile-first modal to make successful submissions more obvious and prevent accidental interaction with the form behind it. 
- Keep using the client-generated submission ID (because the endpoint is submitted in `no-cors` mode) and present it prominently to the user. 
- Surface validation and submission failure messages directly above the `Submit predictions` button so errors are visible where users act, while preserving the existing progress/deadline notes and local storage behavior. 

### Description
- Added a dark-theme modal (`.modal-overlay`, `.success-modal`) and markup including `role="dialog"` and `aria-modal="true"`, and a dynamic `#modalSubmissionId` element that is populated after a successful submission handoff. 
- Added a submit-area error region `#submitErrorArea` placed immediately above the submit button and new helper functions `showSubmitError` / `clearSubmitError` to route validation and network errors there. 
- On successful `fetch` handoff the code now calls `openSuccessModal(submissionId)` (using the client-generated `submission_id`), and the modal provides two CTAs: a `Pay Now` anchor to `https://paypal.me/statmatt14` with `target="_blank" rel="noopener noreferrer"`, and a `Continue` button that closes the modal. 
- Added keyboard support to close the modal with `Escape`, kept form values and `localStorage` intact after submission, and ensured the submit button enable/disable and progress text logic remain functional. 

### Testing
- Verified the updated file contains the modal markup via a content check using `node -e` that looked for `successModalOverlay` and returned success. 
- Performed static/script wiring checks to confirm new functions and elements (`#submitErrorArea`, `openSuccessModal`, `modalSubmissionId`, `continueBtn`) are present and connected in `wc26.html`. 
- Created the PR payload (title/body) via the automated `make_pr` call which completed successfully; browser/manual UX verification is recommended for the full checklist (modal appearance, focus management, mobile layout and Pay Now behavior).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc52899088832fba4cbbbf46da1efd)