### PR TITLE
Update WC26 Rules page with 2026 Game Rules and CTAs

### DIFF
--- a/wc26/rules/index.html
+++ b/wc26/rules/index.html
@@ -1,1 +1,116 @@
-<!doctype html><html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>MC Predict | WC26 Rules</title><link rel='stylesheet' href='/style.css'><style>:root{--border:rgba(255,255,255,.12)}body{margin:0;font-family:'Proxima Nova',Arial,sans-serif;color:#f4f4f4;background:radial-gradient(circle at top,#2a2c33 0%,#1b1c20 42%,#111214 100%)}.wrap{max-width:900px;margin:0 auto;padding:16px 14px 60px}.card{background:linear-gradient(145deg,rgba(48,49,56,.95),rgba(28,29,33,.95));border:1px solid var(--border);border-radius:16px;padding:18px}.section-nav{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 12px}.section-nav a{text-decoration:none;color:#dfe6ff;background:#2a2c33;border:1px solid var(--border);border-radius:999px;padding:8px 12px;font-size:.82rem}.section-nav a.active{background:linear-gradient(135deg,rgba(42,57,141,.45),rgba(230,29,37,.35));border-color:rgba(230,29,37,.8)}h2{margin-top:16px}</style></head><body><main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/'>Payment</a><a href='/wc26/rules/' class='active' aria-current='page'>Rules</a><a href='/wc26/table/'>League Table</a><a href='/wc26/halloffame/'>Hall Of Fame</a></nav><section class='card'><h1>Rules / FAQs</h1><h2>How to enter</h2><ul><li>Submit your predictions for all 72 group-stage fixtures.</li><li>Pay the entry fee to validate your entry.</li><li>You can submit again before the deadline if you want to change your predictions.</li></ul><h2>Deadline</h2><ul><li>Entries close at 11:59pm UK time on Wednesday 10th June 2026.</li><li>Only submissions received before the deadline will count.</li></ul><h2>Multiple submissions</h2><p>Multiple submissions are allowed, but only your latest valid submission before the deadline will be used.</p><h2>Payment</h2><p>Your entry is only valid once the entry fee has been paid.</p><h2>Scoring</h2><p>Placeholder: scoring rules will be confirmed before launch.</p><h2>Contact</h2><p>Placeholder: contact MC Predict if you have issues with your submission or payment.</p><p><a href='/wc26/scores/'>Submit Predictions</a> · <a href='/wc26/payment/'>Make Payment</a> · <a href='/wc26/'>Back to World Cup Menu</a></p></section></main></body></html>
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width,initial-scale=1'>
+  <title>MC Predict | WC26 Rules</title>
+  <link rel='stylesheet' href='/style.css'>
+  <style>
+    :root { --border: rgba(255,255,255,.12); }
+    body {
+      margin: 0;
+      font-family: 'Proxima Nova', Arial, sans-serif;
+      color: #f4f4f4;
+      background: radial-gradient(circle at top,#2a2c33 0%,#1b1c20 42%,#111214 100%);
+    }
+    .wrap { max-width: 900px; margin: 0 auto; padding: 16px 14px 60px; }
+    .card {
+      background: linear-gradient(145deg,rgba(48,49,56,.95),rgba(28,29,33,.95));
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 18px;
+    }
+    .section-nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 12px; }
+    .section-nav a {
+      text-decoration: none;
+      color: #dfe6ff;
+      background: #2a2c33;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 8px 12px;
+      font-size: .82rem;
+    }
+    .section-nav a.active {
+      background: linear-gradient(135deg,rgba(42,57,141,.45),rgba(230,29,37,.35));
+      border-color: rgba(230,29,37,.8);
+    }
+    h1 { margin: 0 0 8px; }
+    h2 { margin: 8px 0 16px; color: #dfe6ff; }
+    .rules-list {
+      margin: 0;
+      padding-left: 1.2rem;
+      line-height: 1.55;
+    }
+    .rules-list > li { margin-bottom: 12px; }
+    .rules-list ul,
+    .rules-list ol { margin-top: 8px; padding-left: 1.2rem; }
+    .rules-list li li { margin-bottom: 6px; }
+    .cta-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 20px;
+    }
+    .cta-row a {
+      text-decoration: none;
+      color: #fff;
+      background: linear-gradient(135deg,rgba(42,57,141,.7),rgba(230,29,37,.65));
+      border: 1px solid rgba(255,255,255,.2);
+      border-radius: 10px;
+      padding: 10px 14px;
+      font-weight: 600;
+      font-size: .92rem;
+    }
+  </style>
+</head>
+<body>
+  <main class='wrap'>
+    <nav class='section-nav'>
+      <a href='/wc26/'>Menu</a>
+      <a href='/wc26/scores/'>Submit Predictions</a>
+      <a href='/wc26/payment/'>Payment</a>
+      <a href='/wc26/rules/' class='active' aria-current='page'>Rules</a>
+      <a href='/wc26/table/'>League Table</a>
+      <a href='/wc26/halloffame/'>Hall Of Fame</a>
+    </nav>
+
+    <section class='card'>
+      <h1>Rules / FAQs</h1>
+      <h2>2026 Game Rules</h2>
+
+      <ol class='rules-list'>
+        <li><strong>Deadline:</strong> All entries must be submitted and paid for before 11:59pm UK time on Wednesday 10th June 2026.</li>
+        <li>All predictions of all players will be posted on the website before the first fixture of the 2026 World Cup starts.</li>
+        <li><strong>Scoring system:</strong>
+          <ol type='a'>
+            <li>1 point for a correctly predicted result (1x2 market)</li>
+            <li>1 point for a correctly predicted under/over 2.5 goals</li>
+            <li>2 points for a correctly predicted score</li>
+            <li>The maximum number of points a player can score from any match is 4 points.</li>
+          </ol>
+        </li>
+        <li>All three categories will be scored from the one score you predict for each game.</li>
+        <li><strong>Tie-breakers:</strong> If any two positions in the league table are tied at the end of the tournament on overall points, the final positions will be decided on the following priority order:
+          <ol type='a'>
+            <li>Correct scores (multiple outcomes)</li>
+            <li>Correct results (3 possible outcomes)</li>
+            <li>Correct under/over 2.5 goals (2 possible outcomes)</li>
+            <li>A tie-breaker question</li>
+            <li>A secondary tie-breaker using the knockout stage games.</li>
+          </ol>
+        </li>
+        <li>If a fixture is postponed, the original prediction will carry over to when the game takes place.</li>
+        <li>If a fixture is cancelled, all players will score 0 points for the fixture.</li>
+        <li>All predictions are based on the group stages of the 2026 World Cup only.</li>
+        <li><strong>Incorrect predictions:</strong> Predictions that are input incorrectly, for example you typed in 2-0 but meant 0-2, will not be fixed regardless of how obvious the error may seem.</li>
+      </ol>
+
+      <div class='cta-row'>
+        <a href='/wc26/scores/'>Submit Predictions</a>
+        <a href='/wc26/payment/'>Make Payment</a>
+        <a href='/wc26/'>Back to World Cup Menu</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Replace the placeholder Rules/FAQs content with the finalized World Cup 2026 rules while keeping the WC26 dark theme, section navigation, and page layout intact. 
- Present the official deadline, scoring details, tie-breaker order, and other policy text clearly and mobile-friendly so players can quickly understand entry requirements.

### Description

- Replaced the content of `wc26/rules/index.html` with a styled Rules / FAQs page where the main heading reads `2026 Game Rules` and the page retains existing WC26 navigation and dark card layout. 
- Added a numbered list of the 9 rules with nested alphabetical lists for the **Scoring system** and the **Tie-breakers** priority order, and bolded key phrases like **Deadline**, **Scoring system**, **Tie-breakers**, and **Incorrect predictions** for clarity. 
- Kept responsive-friendly styling and added a CTA row with buttons linking to `/wc26/scores/`, `/wc26/payment/`, and `/wc26/` so users can submit predictions, make payment, or return to the menu. 
- Ensured wording uses the requested terms such as `under/over 2.5 goals`, `Correct results`, `Correct scores`, and `knockout stage games` without changing rule meanings.

### Testing

- Located the rules file with `rg` and confirmed `wc26/rules/index.html` exists and was updated. (succeeded)
- Ran a content validation script using `python - <<'PY' ...` to verify the `2026 Game Rules` heading, removal of placeholder text, presence of all rule items, nested scoring and tie-breaker lists, section navigation, and CTA links; the script returned success. (succeeded)
- Printed the updated source with `nl -ba wc26/rules/index.html | sed -n '1,260p'` to inspect the final HTML and confirm layout, lists, and CTA markup are present. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc66409654832f8af5edd5ba934f79)