### PR TITLE
Revamp WC26 Hall Of Fame page with premium tournament showcase

### DIFF
--- a/wc26/halloffame/index.html
+++ b/wc26/halloffame/index.html
@@ -1,23 +1,193 @@
-<!doctype html><html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>MC Predict | WC26 Hall Of Fame</title><link rel='stylesheet' href='/style.css'><style>:root{--border:rgba(255,255,255,.12)}body{margin:0;font-family:'Proxima Nova',Arial,sans-serif;color:#f4f4f4;background:radial-gradient(circle at top,#2a2c33 0%,#1b1c20 42%,#111214 100%)}.wrap{max-width:860px;margin:0 auto;padding:16px 14px 60px}.card{background:linear-gradient(145deg,rgba(48,49,56,.95),rgba(28,29,33,.95));border:1px solid var(--border);border-radius:16px;padding:18px}.section-nav{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 12px}.section-nav a{text-decoration:none;color:#dfe6ff;background:#2a2c33;border:1px solid var(--border);border-radius:999px;padding:8px 12px;font-size:.82rem}.section-nav a.active{background:linear-gradient(135deg,rgba(42,57,141,.45),rgba(230,29,37,.35));border-color:rgba(230,29,37,.8)}</style>
+<!doctype html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width,initial-scale=1'>
+  <title>MC Predict | WC26 Hall Of Fame</title>
+  <link rel='stylesheet' href='/style.css'>
   <style>
-    .home-topbar{padding-bottom:8px;margin:14px auto 8px;max-width:1120px;padding-left:14px;padding-right:14px;}
-    .topbar-inner{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:16px;background:linear-gradient(135deg,#3a3a3c,#262628);box-shadow:0 12px 25px rgba(0,0,0,.45);}
-    .brand-header-link{display:flex;align-items:center;gap:10px;min-width:0;text-decoration:none;color:inherit;border-radius:12px;}
-    .brand-header-link:focus-visible{outline:2px solid #f7b057;outline-offset:3px;}
-    .topbar-left{display:flex;align-items:center;gap:10px;min-width:0;}
-    .topbar-logo{width:44px;height:44px;border-radius:14px;overflow:hidden;background:radial-gradient(circle at 30% 20%,#f09300,#1d1d1f);display:flex;align-items:center;justify-content:center;flex-shrink:0;}
-    .topbar-logo img{width:70%;height:70%;object-fit:contain;}
-    .topbar-title h1{margin:0;font-size:20px;letter-spacing:.18em;color:#fff;white-space:nowrap;}
-    .topbar-title span{font-size:12px;color:#a5a5a7;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block;}
-    @media (max-width:640px){.home-topbar{padding-left:10px;padding-right:10px;margin-top:10px}.topbar-title h1{font-size:17px;letter-spacing:.14em}}
+    :root {
+      --border: rgba(255, 255, 255, .12);
+      --panel: rgba(30, 31, 36, .95);
+      --gold: #f7c465;
+      --silver: #c9ced8;
+      --bronze: #c98b56;
+      --muted: #b8beca;
+      --shadow: 0 14px 34px rgba(0, 0, 0, .45);
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Proxima Nova', Arial, sans-serif;
+      color: #f4f4f4;
+      background:
+        radial-gradient(circle at 12% 0%, rgba(247, 196, 101, .2) 0%, rgba(247, 196, 101, 0) 34%),
+        radial-gradient(circle at 88% 8%, rgba(216, 168, 90, .16) 0%, rgba(216, 168, 90, 0) 30%),
+        linear-gradient(180deg, #1f2026 0%, #15161a 46%, #101114 100%);
+    }
+
+    .wrap { max-width: 1120px; margin: 0 auto; padding: 16px 14px 64px; }
+
+    .section-nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 16px; }
+    .section-nav a {
+      text-decoration: none; color: #dfe6ff; background: #2a2c33;
+      border: 1px solid var(--border); border-radius: 999px;
+      padding: 8px 12px; font-size: .82rem;
+      transition: transform .2s ease, border-color .2s ease;
+    }
+    .section-nav a:hover { transform: translateY(-1px); border-color: rgba(247,196,101,.55); }
+    .section-nav a.active {
+      background: linear-gradient(135deg, rgba(71, 55, 18, .62), rgba(185, 127, 36, .4));
+      border-color: rgba(247, 196, 101, .8);
+    }
+
+    .hero {
+      background: linear-gradient(145deg, rgba(51, 42, 24, .86), rgba(34, 35, 41, .94));
+      border: 1px solid rgba(247, 196, 101, .36);
+      border-radius: 18px;
+      padding: 26px 22px;
+      box-shadow: var(--shadow), inset 0 1px 0 rgba(255,255,255,.05);
+      margin-bottom: 18px;
+      position: relative;
+      overflow: hidden;
+    }
+    .hero::after {
+      content: '🏆';
+      position: absolute;
+      right: 20px;
+      top: 16px;
+      font-size: 34px;
+      opacity: .6;
+      filter: drop-shadow(0 4px 8px rgba(0,0,0,.45));
+    }
+    .hero h1 { margin: 0 0 10px; font-size: clamp(1.8rem, 3.8vw, 2.5rem); letter-spacing: .04em; }
+    .hero p { margin: 0 0 8px; color: #e9edf8; max-width: 720px; line-height: 1.6; }
+    .hero .subtle { color: #d5d9e5; }
+
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 14px;
+      margin-top: 4px;
+    }
+
+    .tournament {
+      background: linear-gradient(165deg, rgba(43,45,53,.95), var(--panel));
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 16px;
+      box-shadow: 0 10px 26px rgba(0,0,0,.32);
+    }
+    .tournament h2 {
+      margin: 0 0 14px;
+      font-size: 1.08rem;
+      letter-spacing: .03em;
+      color: #fff;
+      padding-bottom: 10px;
+      border-bottom: 1px solid rgba(255,255,255,.12);
+    }
+
+    .rankings { list-style: none; margin: 0; padding: 0; display: grid; gap: 8px; }
+    .rankings li {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 10px 11px;
+      border-radius: 10px;
+      background: rgba(255,255,255,.03);
+      border: 1px solid rgba(255,255,255,.08);
+      font-size: .95rem;
+    }
+    .place { font-weight: 700; min-width: 42px; }
+    .name { color: #f4f6fc; text-align: right; }
+    .first { border-color: rgba(247,196,101,.62); background: linear-gradient(100deg, rgba(247,196,101,.16), rgba(247,196,101,.04)); box-shadow: inset 0 0 0 1px rgba(247,196,101,.14); }
+    .first .place { color: var(--gold); }
+    .second { border-color: rgba(201,206,216,.46); }
+    .second .place { color: var(--silver); }
+    .third { border-color: rgba(201,139,86,.46); }
+    .third .place { color: var(--bronze); }
+    .other .place { color: #d1d6e2; }
+
+    .lost {
+      text-align: center;
+      padding: 20px 12px;
+      border-radius: 12px;
+      border: 1px dashed rgba(247,196,101,.5);
+      background: linear-gradient(165deg, rgba(247,196,101,.08), rgba(255,255,255,.02));
+    }
+    .lost strong { color: var(--gold); font-size: 1.05rem; }
+    .lost p { margin: 10px 0 0; color: var(--muted); font-size: .92rem; }
+
+    .cta-row {
+      margin-top: 22px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .cta-row a {
+      text-decoration: none;
+      color: #f4f4f4;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      padding: 10px 14px;
+      background: linear-gradient(145deg, rgba(48,49,56,.95), rgba(28,29,33,.95));
+      font-weight: 600;
+      letter-spacing: .01em;
+      transition: transform .2s ease, border-color .2s ease;
+    }
+    .cta-row a:hover { transform: translateY(-1px); border-color: rgba(247,196,101,.55); }
+
+    .home-topbar {
+      padding-bottom: 8px;
+      margin: 14px auto 8px;
+      max-width: 1120px;
+      padding-left: 14px;
+      padding-right: 14px;
+    }
+    .topbar-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 10px 12px;
+      border-radius: 16px;
+      background: linear-gradient(135deg, #3a3a3c, #262628);
+      box-shadow: 0 12px 25px rgba(0, 0, 0, .45);
+    }
+    .brand-header-link { display: flex; align-items: center; gap: 10px; min-width: 0; text-decoration: none; color: inherit; border-radius: 12px; }
+    .brand-header-link:focus-visible { outline: 2px solid #f7b057; outline-offset: 3px; }
+    .topbar-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
+    .topbar-logo {
+      width: 44px;
+      height: 44px;
+      border-radius: 14px;
+      overflow: hidden;
+      background: radial-gradient(circle at 30% 20%, #f09300, #1d1d1f);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .topbar-logo img { width: 70%; height: 70%; object-fit: contain; }
+    .topbar-title h1 { margin: 0; font-size: 20px; letter-spacing: .18em; color: #fff; white-space: nowrap; }
+    .topbar-title span { font-size: 12px; color: #a5a5a7; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block; }
+
+    @media (max-width: 640px) {
+      .home-topbar { padding-left: 10px; padding-right: 10px; margin-top: 10px; }
+      .topbar-title h1 { font-size: 17px; letter-spacing: .14em; }
+      .hero::after { font-size: 28px; right: 14px; }
+      .rankings li { font-size: .92rem; }
+    }
   </style>
-</head><body>
-  <header class="home-topbar">
-    <div class="topbar-inner">
-      <a class="brand-header-link" href="/" aria-label="MC Predict home">
-        <div class="topbar-left">
-          <div class="topbar-logo"><img src="/images/mcpredcirclebg.png" alt=""></div>
-          <div class="topbar-title">
+</head>
+<body>
+  <header class='home-topbar'>
+    <div class='topbar-inner'>
+      <a class='brand-header-link' href='/' aria-label='MC Predict home'>
+        <div class='topbar-left'>
+          <div class='topbar-logo'><img src='/images/mcpredcirclebg.png' alt=''></div>
+          <div class='topbar-title'>
             <h1>MC PREDICT</h1>
             <span>Data-driven Football predictions</span>
           </div>
@@ -25,4 +195,89 @@
       </a>
     </div>
   </header>
-<main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/'>Payment</a><a href='/wc26/rules/'>Rules</a><a href='/wc26/table/'>League Table</a><a href='/wc26/halloffame/' class='active' aria-current='page'>Hall Of Fame</a></nav><section class='card'><h1>Hall Of Fame</h1><p>Previous winners and prediction game history will appear here.</p><p><a href='/wc26/table/'>League Table</a> · <a href='/wc26/'>Back to World Cup Menu</a></p></section></main></body></html>
+
+  <main class='wrap'>
+    <nav class='section-nav'>
+      <a href='/wc26/'>Menu</a>
+      <a href='/wc26/scores/'>Submit Predictions</a>
+      <a href='/wc26/payment/'>Payment</a>
+      <a href='/wc26/rules/'>Rules</a>
+      <a href='/wc26/table/'>League Table</a>
+      <a href='/wc26/halloffame/' class='active' aria-current='page'>Hall Of Fame</a>
+    </nav>
+
+    <section class='hero'>
+      <h1>Hall Of Fame</h1>
+      <p>A look back at the previous MC Predict tournament winners and runners-up.</p>
+      <p class='subtle'>The names below have earned their place in MC Predict history.</p>
+    </section>
+
+    <section class='cards' aria-label='MC Predict tournament winners'>
+      <article class='tournament'>
+        <h2>Euro 2024</h2>
+        <ul class='rankings'>
+          <li class='first'><span class='place'>1st 🥇</span><span class='name'>Aaron Crosbie</span></li>
+          <li class='second'><span class='place'>2nd 🥈</span><span class='name'>Sean Floyd</span></li>
+          <li class='third'><span class='place'>3rd 🥉</span><span class='name'>Corey Chambers</span></li>
+          <li class='other'><span class='place'>4th</span><span class='name'>James Doyle</span></li>
+        </ul>
+      </article>
+
+      <article class='tournament'>
+        <h2>World Cup 2022</h2>
+        <ul class='rankings'>
+          <li class='first'><span class='place'>1st 🥇</span><span class='name'>Will Ellis</span></li>
+          <li class='second'><span class='place'>2nd 🥈</span><span class='name'>Callum Birmingham</span></li>
+          <li class='third'><span class='place'>3rd 🥉</span><span class='name'>Jordan Rudge</span></li>
+          <li class='other'><span class='place'>4th</span><span class='name'>Harry Nisbet</span></li>
+          <li class='other'><span class='place'>5th</span><span class='name'>Dan Webster</span></li>
+        </ul>
+      </article>
+
+      <article class='tournament'>
+        <h2>Euro 2020 (2021)</h2>
+        <ul class='rankings'>
+          <li class='first'><span class='place'>1st 🥇</span><span class='name'>Tom Scholes</span></li>
+          <li class='second'><span class='place'>2nd 🥈</span><span class='name'>Sean Banner</span></li>
+          <li class='third'><span class='place'>3rd 🥉</span><span class='name'>Liam Parsons</span></li>
+          <li class='other'><span class='place'>4th</span><span class='name'>Tony &amp; Jackie Moremon</span></li>
+          <li class='other'><span class='place'>5th</span><span class='name'>Dan Webster</span></li>
+        </ul>
+      </article>
+
+      <article class='tournament'>
+        <h2>World Cup 2018</h2>
+        <ul class='rankings'>
+          <li class='first'><span class='place'>1st 🥇</span><span class='name'>Liam Parsons</span></li>
+          <li class='second'><span class='place'>2nd 🥈</span><span class='name'>Chris Miller</span></li>
+          <li class='third'><span class='place'>3rd 🥉</span><span class='name'>Mark Keaney</span></li>
+          <li class='other'><span class='place'>4th</span><span class='name'>Sean Banner</span></li>
+          <li class='other'><span class='place'>5th</span><span class='name'>Tom Scholes</span></li>
+        </ul>
+      </article>
+
+      <article class='tournament'>
+        <h2>Euro 2016</h2>
+        <div class='lost'>
+          <strong>Lost the data!</strong>
+          <p>The archive has gone missing for this one.</p>
+        </div>
+      </article>
+
+      <article class='tournament'>
+        <h2>World Cup 2014</h2>
+        <ul class='rankings'>
+          <li class='first'><span class='place'>1st 🥇</span><span class='name'>Lee Gerke</span></li>
+          <li class='second'><span class='place'>2nd 🥈</span><span class='name'>Lewis Dunwoody</span></li>
+        </ul>
+      </article>
+    </section>
+
+    <nav class='cta-row' aria-label='Hall of Fame actions'>
+      <a href='/wc26/'>Back to World Cup Menu</a>
+      <a href='/wc26/scores/'>Submit Predictions</a>
+      <a href='/wc26/rules/'>View Rules</a>
+    </nav>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Replace the placeholder Hall Of Fame with a polished, regal page that celebrates past MC Predict tournament winners while keeping the WC26 dark theme and existing header/navigation. 
- Surface previous winners with clear hierarchy (gold/silver/bronze treatment) so historical results are easy to scan and feel prestigious.

### Description

- Replaced `wc26/halloffame/index.html` content with a new premium-styled layout including a hero section, responsive tournament cards, and gold-accented dark visuals. 
- Implemented distinct visual treatments for `1st`/`2nd`/`3rd` and understated styles for `4th`/`5th`, plus a polished `Lost the data!` block for Euro 2016. 
- Added all requested tournaments and exact names/titles: `Euro 2024`, `World Cup 2022`, `Euro 2020 (2021)`, `World Cup 2018`, `Euro 2016`, and `World Cup 2014`. 
- Added bottom CTA links to ` /wc26/ `, ` /wc26/scores/ `, and ` /wc26/rules/ ` and preserved the MC Predict brand header and WC26 section navigation; no other WC26 pages were modified.

### Testing

- Ran an automated content validation script that read `wc26/halloffame/index.html` and verified the placeholder text was removed and all required tournament titles and names were present, and the check passed. 
- Programmatically inspected the updated file to confirm the presence of the hero copy (`Hall Of Fame` and intro lines), each tournament block (including `Lost the data!` for Euro 2016), and the bottom CTAs, and this verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7c4cfd04832fb722b81d700a0175)