### PR TITLE
Hide flags and team codes in WC26 scores fixture rows (render team names only)

### DIFF
--- a/wc26/scores/index.html
+++ b/wc26/scores/index.html
@@ -430,11 +430,11 @@
           fixturesContainer.insertAdjacentHTML('beforeend', `
             <article class="fixture">
               <div class="group-label">${fx.group} • ${fx.kickoff_time}</div>
-              <div class="team-home"><span>${fx.home_team}</span> <span class="team-code">${fx.home_team_code || ''}</span> <span class="team-flag" aria-hidden="true">${fx.home_flag || ''}</span></div>
+              <div class="team-home"><span>${fx.home_team}</span></div>
               <input class="score-input" data-key="${fx.fixture_id}:home" inputmode="numeric" maxlength="1" aria-label="${fx.home_team} score against ${fx.away_team}" ${isClosed() ? 'disabled' : ''}>
               <span class="score-sep">-</span>
               <input class="score-input" data-key="${fx.fixture_id}:away" inputmode="numeric" maxlength="1" aria-label="${fx.away_team} score against ${fx.home_team}" ${isClosed() ? 'disabled' : ''}>
-              <div class="team-away"><span class="team-flag" aria-hidden="true">${fx.away_flag || ''}</span> <span class="team-code">${fx.away_team_code || ''}</span> <span>${fx.away_team}</span></div>
+              <div class="team-away"><span>${fx.away_team}</span></div>
             </article>
           `);
         });


### PR DESCRIPTION
### Motivation
- Desktop fixture rows were showing broken flag/code fallback text (e.g., `MX`, `ZA`) and cluttering the UI, so the fixture row markup should render only the team names around the score inputs.

### Description
- Updated the fixture rendering in `wc26/scores/index.html` to remove visual output of `home_team_code`, `away_team_code`, `home_flag`, and `away_flag` so each row now contains only the home team name, score inputs, and away team name.
- Kept CSV parsing, local storage, validation, auto-advance, tie-breaker, and submission payload construction unchanged so `home_team_code`, `away_team_code`, `home_flag`, and `away_flag` remain present in the submitted `predictions` objects.

### Testing
- No automated tests were executed in this environment; please verify the page in a browser to confirm desktop rows show only names and that score inputs, auto-advance, local save, validation, and submission payload remain functional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc82b05d64832f86df3c503cb1f9fd)