### PR TITLE
Restore emoji indicators in value badges on Test.html

### DIFF
--- a/Test.html
+++ b/Test.html
@@ -90,7 +90,7 @@
     .roi-hero { font-size:.96rem; font-weight:700; color:#9adfb5; }
     .metric-support { color:var(--muted); font-size:.82rem; }
     .metric-support span { white-space:nowrap; }
-    .badge { display:inline-flex; width:max-content; font-size:.72rem; padding:4px 9px; border-radius:999px; font-weight:700; border:1px solid var(--border); background:#282c32; color:#d7dde7; }
+    .badge { display:inline-flex; align-items:center; gap:6px; width:max-content; font-size:.72rem; padding:4px 9px; border-radius:999px; font-weight:700; border:1px solid var(--border); background:#282c32; color:#d7dde7; white-space:nowrap; }
     .badge-strong { color:#8df0b3; border-color:rgba(51,196,110,.5); background:rgba(51,196,110,.16); }
     .badge-good { color:#a3e7bf; border-color:rgba(51,196,110,.35); background:rgba(51,196,110,.1); }
     .badge-value { color:#d4e8dc; }
@@ -230,19 +230,21 @@
         .filter(item => item.fixture);
     }
 
-    function getValueLabel(value) {
+    function getValueBadgeContent(value) {
       const text = cleanCell(value);
       const moneyBagCount = (text.match(/💰/g) || []).length;
       const crossCount = (text.match(/❌|✕|x/gi) || []).length;
-      if (moneyBagCount >= 3) return 'Strong Value';
-      if (moneyBagCount === 2) return 'Good Value';
-      if (moneyBagCount === 1) return 'Value';
-      if (crossCount >= 1) return 'Low Value';
-      return text || '-';
+      if (moneyBagCount >= 3) return { indicator: '💰💰💰', label: 'Strong Value', fullText: '💰💰💰 Strong Value' };
+      if (moneyBagCount === 2) return { indicator: '💰💰', label: 'Good Value', fullText: '💰💰 Good Value' };
+      if (moneyBagCount === 1) return { indicator: '💰', label: 'Value', fullText: '💰 Value' };
+      if (crossCount >= 3) return { indicator: '❌❌❌', label: 'Low Value', fullText: '❌❌❌ Low Value' };
+      if (crossCount === 2) return { indicator: '❌❌', label: 'Low Value', fullText: '❌❌ Low Value' };
+      if (crossCount === 1) return { indicator: '❌', label: 'Low Value', fullText: '❌ Low Value' };
+      return { indicator: '', label: text || '-', fullText: text || '-' };
     }
 
     function getValueBadgeClass(value) {
-      const label = getValueLabel(value).toLowerCase();
+      const label = getValueBadgeContent(value).label.toLowerCase();
       if (label.includes('strong')) return 'badge badge-strong';
       if (label.includes('good')) return 'badge badge-good';
       if (label === 'value') return 'badge badge-value';
@@ -265,7 +267,7 @@
           <div class="pick-title">${r.fixture || '-'}</div>
           <div class="pick-sub">Market ${r.bookiePrice || '-'} · Model ${r.modelPrice || '-'}</div>
           ${type === 'value'
-            ? `<span class="${getValueBadgeClass(r.value)}">${getValueLabel(r.value)}</span>`
+            ? `<span class="${getValueBadgeClass(r.value)}">${getValueBadgeContent(r.value).fullText}</span>`
             : `<span class="confidence-chip">${r.confidence || '-'} confidence</span>`}
         </article>`).join('')}</div>`;
     }
@@ -344,7 +346,7 @@
               <span class="roi-hero ${cleanCell(c.roi).includes('-') ? 'neg' : ''}">${c.roi || '-'} ROI</span>
             </div>
             <div class="metric-support"><span>${c.bets || '-'} bets</span> · <span>${c.hitRate || '-'} hit rate</span> · <span>${c.avgOdds || '-'} avg odds</span></div>
-            <span class="${getValueBadgeClass(c.value)}">${getValueLabel(c.value)}</span>
+            <span class="${getValueBadgeClass(c.value)}">${getValueBadgeContent(c.value).fullText}</span>
           </article>`;
         }).join('')}</div>`;
       } catch (e) {


### PR DESCRIPTION
### Motivation
- Value badges lost their original emoji indicators when rendered, removing key visual signals (💰 / ❌) that users rely on to interpret picks quickly.
- The change must be display-only, keep fixed-cell extraction and Google Sheet URLs, and present the emoji on the left of the human-readable label.

### Description
- Replaced the label-only helper with `getValueBadgeContent(value)` which parses the source text and returns `{ indicator, label, fullText }` for money-bag and cross counts and preserves other text when no indicator exists. 
- Updated `getValueBadgeClass` to derive classes from `getValueBadgeContent(...).label` so existing color classes (`badge-strong`, `badge-good`, `badge-value`, `badge-low`) remain unchanged. 
- Rendered `fullText` (emoji(s) prepended to label) in both display locations: Today’s Top Value Picks and Best Performing Angles, without hardcoding any values or changing data extraction ranges. 
- Adjusted `.badge` CSS to `inline-flex` with `align-items`, `gap` and `white-space: nowrap` so emojis sit neatly to the left and badges remain compact and mobile-friendly; only `Test.html` was edited.

### Testing
- Confirmed the updated helper and render sites by searching and inspecting `Test.html` to ensure both places now use `getValueBadgeContent(...).fullText`, and that `getValueBadgeClass` uses the new label (search/inspection succeeded). 
- Verified visual/CSS changes by viewing the updated `.badge` rules in `Test.html` (inspection succeeded). 
- Performed repository checks with `git status`, `git diff -- Test.html`, and committed the change, and confirmed only `Test.html` was modified and `index.html` was not edited (commands succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc5663a94832f8f4aa2abf9b76bca)