### PR TITLE
Prioritize ROI in Best Performing Angles cards (Test.html)

### DIFF
--- a/Test.html
+++ b/Test.html
@@ -86,12 +86,10 @@
     .angle-card.best .rank-badge { min-width:40px; height:40px; color:var(--accent); background:rgba(247,147,26,.2); border:1px solid rgba(247,147,26,.45); }
     .best-performer { font-size:.68rem; text-transform:uppercase; letter-spacing:.08em; color:var(--accent); font-weight:800; }
     .angle-title { font-size:1rem; font-weight:700; margin-top:2px; }
-    .metric-line { display:flex; gap:10px; align-items:baseline; flex-wrap:wrap; }
-    .profit-hero { font-size:1.3rem; font-weight:800; color:var(--text); }
-    .angle-card.best .profit-hero { font-size:1.38rem; }
-    .roi-hero { font-size:.92rem; font-weight:800; color:#9adfb5; white-space:nowrap; }
-    .metric-support { color:var(--muted); font-size:.82rem; }
-    .metric-support span { white-space:nowrap; }
+    .metric-line { display:grid; gap:4px; }
+    .roi-hero { font-size:1rem; font-weight:800; color:#9adfb5; white-space:nowrap; }
+    .profit-support { font-size:.86rem; font-weight:700; color:var(--muted); white-space:nowrap; }
+    .profit-support.pos { color:#b9d9c6; }
     .badge { display:inline-flex; align-items:center; gap:6px; width:max-content; font-size:.72rem; padding:4px 9px; border-radius:999px; font-weight:700; border:1px solid var(--border); background:#282c32; color:#d7dde7; white-space:nowrap; }
     .value-badge { display:inline-flex; align-items:center; gap:6px; border-radius:999px; padding:5px 9px; font-size:11px; font-weight:800; line-height:1; white-space:nowrap; max-width:100%; }
     .angle-stats { display:flex; flex-wrap:wrap; align-items:center; gap:4px; color:var(--muted); font-size:13px; }
@@ -359,8 +357,8 @@
               </div>
             </div>
             <div class="metric-line">
-              <span class="profit-hero ${isNeg ? 'neg' : 'pos'}">${profitText}</span>
               <span class="roi-hero ${cleanCell(c.roi).includes('-') ? 'neg' : ''}">${c.roi || '-'} ROI</span>
+              <span class="profit-support ${isNeg ? 'neg' : 'pos'}">${profitText}</span>
             </div>
             <div class="angle-stats">
               <span><strong>${c.bets || '-'}</strong> <span>bets</span></span>


### PR DESCRIPTION
### Motivation
- Make ROI the primary, feature stat in the Best Performing Angles cards and demote Profit/Loss to a supporting stat while preserving existing data and badges.  
- Ensure the ROI typography matches the card title scale so it is no longer oversized like the previous Profit/Loss hero metric.  
- Preserve rank-1 styling, value badge placement/emojis, and the fixed-cell data extraction logic (E34:L36).  

### Description
- Updated `Test.html` to render the ROI element before Profit/Loss in the Best Performing Angles card template.  
- Reworked the metric styles: changed `.metric-line` layout to a stacked grid, added `.roi-hero` at ~1rem bold and `.profit-support` as a smaller, muted supporting stat with preserved positive/negative color treatment.  
- Kept all data mapping and extraction intact (`rows.slice(33, 36)` with ROI at index `11` and profit/loss at index `10`) and did not modify any Google Sheet URLs or other files.  
- Only `Test.html` was edited; no changes to `/index.html` or any business logic were made.  

### Testing
- Ran `git status --short` to confirm only `Test.html` was modified and this check succeeded.  
- Committed the change with `git add Test.html && git commit -m "Adjust Best Performing Angles metric hierarchy to prioritize ROI"` and the commit succeeded showing one file changed.  
- Inspected the updated CSS and template with `nl -ba Test.html | sed -n '90,160p'` and `nl -ba Test.html | sed -n '320,390p'` to verify the style and DOM order changes, which matched the intended update.  
- Final `git status --short` showed a clean working tree after commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd8fe5794832f96cca62414d1aebf)