### PR TITLE
Add approved mobile bottom navigation to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,26 @@
   </div>
 
 
+  <nav class="mobile-bottom-nav" aria-label="Mobile primary navigation">
+    <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value" aria-label="Match Result value predictions">
+      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg>
+      <span class="mobile-bottom-nav__label">Winner</span>
+    </a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value" aria-label="Under Over 2.5 value predictions">
+      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg>
+      <span class="mobile-bottom-nav__label">U/O 2.5</span>
+    </a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical" aria-label="Historical data">
+      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V9M12 19V5M19 19v-7"/></svg>
+      <span class="mobile-bottom-nav__label">Data</span>
+    </a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs" aria-label="FAQs">
+      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg>
+      <span class="mobile-bottom-nav__label">FAQs</span>
+    </a>
+  </nav>
+
+
   <script>
     const HOMEPAGE_CSV = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=799163917&single=true&output=csv';
     const WHATS_HOT_CSV = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRoeausAAqFFCFoB0NK4vjsgmmzxP_J-WtgvUdusuau-jmJ3d3fqPAAa_ujd7nGYag5rJFOysZZUYiA/pub?gid=56710734&single=true&output=csv';


### PR DESCRIPTION
### Motivation
- Bring the approved mobile sticky footer navigation from `/Test.html` into the live homepage so mobile users see the same bottom nav experience.
- Preserve all existing homepage behaviour, layout, Google Sheet URLs, title bar and burger menu while adding the mobile-only sticky footer.
- Ensure active-state behavior and iPhone safe-area support match the approved implementation.

### Description
- Added the approved `.mobile-bottom-nav` HTML markup (four items: Winner, U/O 2.5, Data, FAQs) into `index.html`, copying the inline SVG icons and exact labels/links from `/Test.html`.
- Did not change `/Test.html`, `style.css`, or `site.js`; the existing mobile-only styling, safe-area padding and active-state logic in `style.css` and `site.js` are reused.
- Kept links exactly as required: `Winner → /hda-value`, `U/O 2.5 → /uo-value`, `Data → /historical`, `FAQs → /faqs`.

### Testing
- Verified presence of styles and markup using `rg` searches for `mobile-bottom-nav`, `data-nav-path` and related selectors and confirmed matching CSS blocks in `index.html` and `Test.html` (searches succeeded).
- Inserted the nav block into `index.html` and confirmed the file change via `git status --short` and a successful `git commit -m "Add approved mobile bottom nav to homepage"`.
- Inspected `site.js` to confirm active-state normalization already handles `.html` and non-`.html` paths and that the nav item activation logic is present (inspection succeeded).
- Final verification confirmed `index.html` now contains `.mobile-bottom-nav` markup and four required items, and no other homepage data-loading or sheet URLs were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfa52e534832f98ce2771f825be7e)