### PR TITLE
Fix homepage mobile overflow in Best Performing Strategies cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,14 +17,17 @@
       --green: #33c46e;
       --shadow: 0 10px 30px rgba(0,0,0,.35);
     }
-    * { box-sizing: border-box; }
+    *, *::before, *::after { box-sizing: border-box; }
+    html, body { width: 100%; max-width: 100%; overflow-x: hidden; }
     body {
       margin: 0;
       font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       background: radial-gradient(circle at top left, #23262b, var(--bg) 45%);
       color: var(--text);
     }
-    .container { max-width: 1120px; margin: 0 auto; padding: 12px 14px 34px; }
+    .container { width: 100%; max-width: 430px; margin: 0 auto; padding: 12px 14px 34px; }
+    .site-header { display:flex; align-items:center; justify-content:space-between; gap:12px; width:100%; }
+
 
     .header {
       position: sticky; top: 10px; z-index: 20;
@@ -81,21 +84,21 @@
     @keyframes shimmer { 0% { background-position:100% 0;} 100%{ background-position:0 0;} }
 
     .angles-list { display:grid; gap:10px; }
-    .angle-card { border:1px solid var(--border); border-radius:14px; padding:12px; background:var(--card-2); display:grid; grid-template-columns:minmax(0,1fr) auto; gap:12px; align-items:start; }
+    .angle-card { width:100%; max-width:100%; border:1px solid var(--border); border-radius:14px; padding:12px; background:var(--card-2); display:grid; grid-template-columns:minmax(0,1fr) minmax(0,auto); gap:12px; align-items:start; overflow:hidden; }
     .angle-card.best { border-color: rgba(247,147,26,.6); box-shadow: inset 0 0 0 1px rgba(247,147,26,.25), 0 0 20px rgba(247,147,26,.12); }
     .angle-card__left { min-width:0; }
-    .angle-card__right { display:grid; justify-items:end; gap:18px; min-width:120px; }
-    .angle-card__top-actions { display:flex; align-items:center; justify-content:flex-end; gap:8px; }
+    .angle-card__right { display:grid; justify-items:end; gap:18px; min-width:0; max-width:100%; }
+    .angle-card__top-actions { display:flex; align-items:center; justify-content:flex-end; gap:8px; min-width:0; flex-wrap:wrap; }
     .rank-badge { min-width:34px; height:34px; border-radius:11px; display:grid; place-items:center; background:#2a2d33; color:#d7dbe2; font-weight:700; }
     .angle-card.best .rank-badge { min-width:40px; height:40px; color:var(--accent); background:rgba(247,147,26,.2); border:1px solid rgba(247,147,26,.45); }
     .best-performer { font-size:.68rem; text-transform:uppercase; letter-spacing:.08em; color:var(--accent); font-weight:800; }
     .angle-title { font-size:1rem; font-weight:700; margin-top:2px; }
     .angle-metrics { text-align:right; display:grid; gap:5px; }
-    .roi-hero { font-size:1rem; font-weight:800; color:#9adfb5; white-space:nowrap; }
-    .profit-support { font-size:.83rem; font-weight:700; color:var(--muted); white-space:nowrap; }
+    .roi-hero { font-size:1rem; font-weight:800; color:#9adfb5; white-space:normal; overflow-wrap:anywhere; }
+    .profit-support { font-size:.83rem; font-weight:700; color:var(--muted); white-space:normal; overflow-wrap:anywhere; }
     .profit-support.pos { color:#b9d9c6; }
-    .badge { display:inline-flex; align-items:center; gap:6px; width:max-content; font-size:.72rem; padding:4px 9px; border-radius:999px; font-weight:700; border:1px solid var(--border); background:#282c32; color:#d7dde7; white-space:nowrap; }
-    .value-badge { display:inline-flex; align-items:center; gap:6px; border-radius:999px; padding:5px 9px; font-size:11px; font-weight:800; line-height:1; white-space:nowrap; max-width:150px; overflow:hidden; text-overflow:ellipsis; }
+    .badge { display:inline-flex; align-items:center; gap:6px; width:max-content; max-width:100%; font-size:.72rem; padding:4px 9px; border-radius:999px; font-weight:700; border:1px solid var(--border); background:#282c32; color:#d7dde7; white-space:normal; overflow-wrap:anywhere; }
+    .value-badge { display:inline-flex; align-items:center; gap:6px; border-radius:999px; padding:5px 9px; font-size:11px; font-weight:800; line-height:1.15; white-space:normal; max-width:100%; overflow-wrap:anywhere; }
     .angle-stats--stacked { display:grid; gap:4px; margin-top:14px; font-size:13px; line-height:1.25; }
     .angle-stats--stacked strong { color:var(--text); font-weight:800; }
     .angle-stats--stacked span { color:var(--muted); }
@@ -117,10 +120,11 @@
       .angles-list { grid-template-columns: 1fr 1fr; }
       .angle-card.best { grid-column: 1 / -1; }
     }
-    @media (max-width: 370px) {
-      .angle-card { grid-template-columns:minmax(0,1fr) 118px; gap:8px; }
-      .value-badge { font-size:10px; padding:5px 7px; max-width:112px; }
-      .angle-title, .roi-hero { font-size:15px; }
+    @media (max-width: 390px) {
+      .angle-card { padding:10px; gap:8px; grid-template-columns:minmax(0,1fr) minmax(92px, 34%); }
+      .value-badge { font-size:10px; padding:4px 7px; }
+      .angle-title { font-size:.93rem; }
+      .roi-hero { font-size:.92rem; }
       .profit-support, .angle-stats--stacked { font-size:12px; }
     }
 
@@ -223,6 +227,7 @@
 </head>
 <body>
 
+  <main class="container">
   <header class="site-header">
     <a class="brand" href="/">
       <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
@@ -286,7 +291,8 @@
       </a>
       <small>Follow MC Predict</small>
     </div>
-  </div>
+
+  </main>
 
   <div class="home-screen-modal" id="homeScreenModal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="homeScreenModalTitle">
     <div class="home-screen-modal__card">

--- a/style.css
+++ b/style.css
@@ -25,6 +25,8 @@ html,
 body {
   margin: 0;
   padding: 0;
+  width: 100%;
+  max-width: 100%;
   height: auto;
   min-height: 100%;
   overflow-y: auto;


### PR DESCRIPTION
### Motivation
- The homepage was susceptible to horizontal clipping on some Android/Samsung viewports where ROI/profit values and rank badges extended past the right edge.  The goal is to prevent overflow without redesigning the page.
- Changes aim to make the page robust against viewport and font scaling differences common on Samsung Internet and other mobile browsers.

### Description
- Added global safety rules by enforcing `*, *::before, *::after { box-sizing: border-box; }` and `html, body { width: 100%; max-width: 100%; overflow-x: hidden; }` in the homepage inline CSS and mirrored the width constraints in `style.css`.
- Constrained the homepage shell by making the `container` use `width: 100%`, `max-width: 430px`, `margin: 0 auto` and wrapped the page content inside `<main class="container">` so page content is consistently bounded on narrow screens.
- Hardened the “Best Performing Strategies” card layout by making `.angle-card` `width:100%`/`max-width:100%`, changing the grid column to `minmax(0,1fr) minmax(0,auto)`, adding `overflow:hidden`, setting `.angle-card__right` `min-width:0`/`max-width:100%`, allowing `.angle-card__top-actions` to `flex-wrap`, and changing `.roi-hero`, `.profit-support`, `.badge`, and `.value-badge` to allow wrapping (`white-space: normal` / `overflow-wrap:anywhere`) so values/badges can shrink or wrap instead of forcing overflow.
- Added a narrow-screen breakpoint at `@media (max-width: 390px)` to reduce card padding and badge/font pressure (smaller `.value-badge` padding, slightly reduced title/ROI sizes) while keeping the visual hierarchy intact.

### Testing
- Static validation: used `diff`/`rg` to verify the inline CSS and `style.css` contain the overflow protections and card rule changes (succeeded).
- Automated viewport validation was attempted via a Playwright script to check widths `360`, `375`, `390`, `412`, `430` and measure `document.documentElement.scrollWidth` vs `window.innerWidth`, but the run failed due to the environment missing Playwright (`Error: Cannot find module 'playwright'`), so runtime viewport assertions did not execute.
- Recommend running the Playwright/visual viewport checks in CI or locally (or on a Samsung S24 / Samsung Internet) to confirm `document.documentElement.scrollWidth <= window.innerWidth` across the listed widths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfb6d843c832fa3a1030e0d7e8f81)