### PR TITLE
Move homepage menu into mobile bottom navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,74 @@
         background: rgba(240, 147, 0, 0.08);
         box-shadow: 0 0 14px rgba(240, 147, 0, 0.16);
       }
+
+      .mobile-bottom-nav__menu-trigger {
+        border: 0;
+        background: transparent;
+        font: inherit;
+        cursor: pointer;
+        padding: 0;
+      }
+      .mobile-bottom-menu {
+        position: fixed;
+        left: 12px;
+        right: 12px;
+        bottom: calc(86px + env(safe-area-inset-bottom));
+        z-index: 990;
+        border-radius: 18px;
+        border: 1px solid rgba(247, 147, 26, 0.25);
+        background: rgba(24, 26, 30, 0.98);
+        box-shadow: 0 14px 28px rgba(0,0,0,.42);
+        padding: 10px;
+        display: grid;
+        gap: 6px;
+        max-height: min(66vh, 520px);
+        overflow-y: auto;
+      }
+      .mobile-bottom-menu[hidden] { display: none; }
+      .mobile-bottom-menu__item {
+        text-decoration: none;
+        color: var(--text);
+        border: 1px solid var(--border);
+        background: var(--card);
+        border-radius: 12px;
+        padding: 12px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        font-size: .9rem;
+        font-weight: 650;
+      }
+      .mobile-bottom-menu__item:hover,
+      .mobile-bottom-menu__item:focus-visible {
+        border-color: rgba(247, 147, 26, 0.58);
+        outline: none;
+      }
+      .mobile-bottom-menu__item--active {
+        color: var(--accent);
+        background: rgba(240, 147, 0, 0.08);
+      }
+      .mobile-bottom-menu__item--disabled {
+        color: #7d8592;
+        border-color: #3a3f47;
+        background: #1d2024;
+        cursor: not-allowed;
+      }
+      .mobile-bottom-menu__meta {
+        display: block;
+        font-size: .72rem;
+        color: #8f97a3;
+        margin-top: 4px;
+        font-weight: 550;
+      }
+      .mobile-bottom-menu-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(8, 9, 11, .45);
+        z-index: 980;
+      }
+      .mobile-bottom-menu-backdrop[hidden] { display: none; }
     }
     @media (min-width: 768px) {
       .mobile-bottom-nav {
@@ -233,7 +301,6 @@
       <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
       <div><h1>MCPredict</h1><p>Data-driven Football predictions</p></div>
     </a>
-    <button class="menu-btn" id="openMenu" aria-label="Open menu">☰</button>
   </header>
 
     <section class="hero">
@@ -318,11 +385,23 @@
       <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V9M12 19V5M19 19v-7"/></svg>
       <span class="mobile-bottom-nav__label">Data</span>
     </a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs" aria-label="FAQs">
-      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg>
-      <span class="mobile-bottom-nav__label">FAQs</span>
-    </a>
+    <button class="mobile-bottom-nav__item mobile-bottom-nav__menu-trigger" id="bottomMenuTrigger" type="button" aria-label="Open navigation menu" aria-expanded="false" aria-controls="bottomMenuPanel">
+      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16"/></svg>
+      <span class="mobile-bottom-nav__label">Menu</span>
+    </button>
   </nav>
+
+  <div class="mobile-bottom-menu-backdrop" id="bottomMenuBackdrop" hidden></div>
+  <section class="mobile-bottom-menu" id="bottomMenuPanel" aria-label="Mobile menu" hidden>
+    <a class="mobile-bottom-menu__item" data-nav-path="/" href="/">Home</a>
+    <a class="mobile-bottom-menu__item" data-nav-path="/hda-value" href="/hda-value">Winner - Best Value</a>
+    <a class="mobile-bottom-menu__item" data-nav-path="/hda-highchance" href="/hda-highchance">Winner - Highest Chance</a>
+    <a class="mobile-bottom-menu__item" data-nav-path="/uo-value" href="/uo-value">U/O 2.5 - Best Value</a>
+    <a class="mobile-bottom-menu__item" data-nav-path="/uo-highchance" href="/uo-highchance">U/O 2.5 - Highest Chance</a>
+    <a class="mobile-bottom-menu__item" data-nav-path="/historical" href="/historical">Historical Data</a>
+    <a class="mobile-bottom-menu__item" data-nav-path="/faqs" href="/faqs">FAQs</a>
+    <div class="mobile-bottom-menu__item mobile-bottom-menu__item--disabled" aria-disabled="true">World Cup 2026 <span class="mobile-bottom-menu__meta">Coming soon</span></div>
+  </section>
 
 
   <script>

--- a/site.js
+++ b/site.js
@@ -1,5 +1,6 @@
 (function(){
   function normalize(path){ return (path||'/').replace(/\/+$|\.html$/g,'') || '/'; }
+
   function initMenu(){
     const overlay=document.getElementById('menuOverlay');
     const open=document.getElementById('openMenu');
@@ -11,12 +12,48 @@
     overlay.addEventListener('click',(e)=>{if(e.target===overlay) closeMenu();});
     document.addEventListener('keydown',(e)=>{if(e.key==='Escape'&&overlay.classList.contains('open')) closeMenu();});
   }
+
   function initBottomNav(){
     const current=normalize(window.location.pathname);
-    document.querySelectorAll('.mobile-bottom-nav__item').forEach((item)=>{
+    document.querySelectorAll('.mobile-bottom-nav__item[data-nav-path]').forEach((item)=>{
       const target=normalize(item.dataset.navPath||item.getAttribute('href'));
       item.classList.toggle('mobile-bottom-nav__item--active', current===target);
     });
+    document.querySelectorAll('.mobile-bottom-menu__item[data-nav-path]').forEach((item)=>{
+      const target=normalize(item.dataset.navPath||item.getAttribute('href'));
+      item.classList.toggle('mobile-bottom-menu__item--active', current===target);
+    });
+
+    const trigger=document.getElementById('bottomMenuTrigger');
+    const panel=document.getElementById('bottomMenuPanel');
+    const backdrop=document.getElementById('bottomMenuBackdrop');
+    if(!trigger||!panel||!backdrop) return;
+
+    const closeBottomMenu=()=>{
+      panel.hidden=true;
+      backdrop.hidden=true;
+      trigger.setAttribute('aria-expanded','false');
+      trigger.classList.remove('mobile-bottom-nav__item--active');
+    };
+    const openBottomMenu=()=>{
+      panel.hidden=false;
+      backdrop.hidden=false;
+      trigger.setAttribute('aria-expanded','true');
+      trigger.classList.add('mobile-bottom-nav__item--active');
+    };
+
+    trigger.addEventListener('click',()=>{
+      if(panel.hidden) openBottomMenu();
+      else closeBottomMenu();
+    });
+    backdrop.addEventListener('click',closeBottomMenu);
+    panel.addEventListener('click',(event)=>{
+      if(event.target.closest('a.mobile-bottom-menu__item')) closeBottomMenu();
+    });
+    document.addEventListener('keydown',(event)=>{
+      if(event.key==='Escape' && !panel.hidden) closeBottomMenu();
+    });
   }
+
   document.addEventListener('DOMContentLoaded',()=>{initMenu();initBottomNav();});
 })();


### PR DESCRIPTION
### Motivation
- Simplify the top header by removing the burger button so the header/title area stays clean while preserving branding. 
- Surface navigation from the bottom navigation area to create a menu that feels connected to the bottom nav on mobile. 
- Provide the requested navigation entries (including a disabled, "Coming soon" World Cup 2026) without removing the existing FAQ page.

### Description
- Removed the top/header burger button from `index.html` and kept the header bar and branding unchanged. 
- Replaced the bottom-nav FAQ item with a burger-style `Menu` trigger placed in the same fourth slot and added a bottom-anchored menu panel and backdrop (`mobile-bottom-menu`, `mobile-bottom-menu-backdrop`) to `index.html`. 
- Added CSS rules to match MC Predict styling (dark background, orange accent, rounded panels) and to keep the menu mobile-first and avoid horizontal overflow. 
- Updated `site.js` to highlight the current page in both the bottom nav and menu, toggle the bottom menu open/close from the trigger, and close the menu on backdrop tap, `Escape`, or after selecting a link; also added the disabled `World Cup 2026` item with a `Coming soon` label.

### Testing
- Ran a diff check with `git status --short && git diff -- index.html site.js` to verify the change set, which succeeded. 
- Inspected the updated files with `nl -ba index.html | sed -n '200,460p' && nl -ba site.js | sed -n '1,220p'` to confirm markup and script updates, which succeeded. 
- Committed the changes with `git commit` to record the update, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfd8a2cd4832fa5adc955558b037e)