### PR TITLE
Fix mobile bottom navigation Menu styling and toggle behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,9 +219,12 @@
       }
 
       .mobile-bottom-nav__menu-trigger {
+        appearance: none;
+        -webkit-appearance: none;
         border: 0;
         background: transparent;
         font: inherit;
+        color: inherit;
         cursor: pointer;
         padding: 0;
       }
@@ -392,7 +395,7 @@
   </nav>
 
   <div class="mobile-bottom-menu-backdrop" id="bottomMenuBackdrop" hidden></div>
-  <section class="mobile-bottom-menu" id="bottomMenuPanel" aria-label="Mobile menu" hidden>
+  <section class="mobile-bottom-menu" id="bottomMenuPanel" aria-label="Mobile menu" aria-hidden="true" hidden>
     <a class="mobile-bottom-menu__item" data-nav-path="/" href="/">Home</a>
     <a class="mobile-bottom-menu__item" data-nav-path="/hda-value" href="/hda-value">Winner - Best Value</a>
     <a class="mobile-bottom-menu__item" data-nav-path="/hda-highchance" href="/hda-highchance">Winner - Highest Chance</a>
@@ -453,6 +456,58 @@
 
     document.getElementById('appleHomeBtn').addEventListener('click', () => {
       showHomeScreenInstructions('apple');
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const bottomMenuTrigger = document.getElementById('bottomMenuTrigger');
+      const bottomMenuPanel = document.getElementById('bottomMenuPanel');
+      const bottomMenuBackdrop = document.getElementById('bottomMenuBackdrop');
+      const menuLinks = bottomMenuPanel ? bottomMenuPanel.querySelectorAll('a.mobile-bottom-menu__item') : [];
+
+      if (!bottomMenuTrigger || !bottomMenuPanel || !bottomMenuBackdrop) return;
+
+      const openBottomMenu = () => {
+        bottomMenuPanel.hidden = false;
+        bottomMenuBackdrop.hidden = false;
+        bottomMenuTrigger.classList.add('mobile-bottom-nav__item--active');
+        bottomMenuTrigger.setAttribute('aria-expanded', 'true');
+        bottomMenuPanel.setAttribute('aria-hidden', 'false');
+      };
+
+      const closeBottomMenu = () => {
+        bottomMenuPanel.hidden = true;
+        bottomMenuBackdrop.hidden = true;
+        bottomMenuTrigger.classList.remove('mobile-bottom-nav__item--active');
+        bottomMenuTrigger.setAttribute('aria-expanded', 'false');
+        bottomMenuPanel.setAttribute('aria-hidden', 'true');
+      };
+
+      const toggleBottomMenu = () => {
+        if (bottomMenuPanel.hidden) {
+          openBottomMenu();
+          return;
+        }
+        closeBottomMenu();
+      };
+
+      bottomMenuTrigger.addEventListener('click', (event) => {
+        event.preventDefault();
+        toggleBottomMenu();
+      });
+
+      bottomMenuBackdrop.addEventListener('click', closeBottomMenu);
+
+      menuLinks.forEach((link) => {
+        link.addEventListener('click', () => {
+          closeBottomMenu();
+        });
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !bottomMenuPanel.hidden) {
+          closeBottomMenu();
+        }
+      });
     });
 
     


### PR DESCRIPTION
### Motivation
- Normalize the new bottom nav "Menu" item so it matches the visual treatment of other nav items when inactive.
- Make the Menu entry an action button that toggles an in-place menu panel rather than navigating to another page.
- Ensure accessible, robust open/close behaviour (backdrop click, Escape, link selection) and proper ARIA state toggling.

### Description
- CSS: updated `.mobile-bottom-nav__menu-trigger` to inherit color/appearance so the Menu item uses the same default style as other items and only shows the active class while open.
- Markup: added `aria-hidden="true"` to the mobile bottom menu panel when closed to keep ARIA state explicit.
- JS: added a `DOMContentLoaded` handler that selects `#bottomMenuTrigger`, `#bottomMenuPanel` and `#bottomMenuBackdrop` and implements `open`, `close` and `toggle` functions which update `hidden`, `aria-expanded` and `aria-hidden` and the active class.
- Interaction: prevent default on trigger clicks so the Menu does not navigate, close the menu on backdrop click, Escape key, and before navigating when a menu link is selected, and ensure the World Cup 2026 item remains greyed out and non-clickable.

### Testing
- Ran targeted source checks with ripgrep for bottom/menu nav identifiers (e.g. `rg -n "bottom|Menu|menu|nav" index.html`) which completed successfully.
- Verified the updated file content ranges with `sed` reads to confirm the new CSS/ARIA/JS blocks were inserted successfully.
- Applied the patch via the project patcher which returned success and left the runtime JS/CSS/HTML changes in `index.html`.
- All automated checks performed in the repository (searches, file reads and patch application) succeeded with no reported errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcff5212c8832f80bc3d06c75dbbbc)