### PR TITLE
Fix homepage Google Sheets data loading regression after nav/layout update

### DIFF
--- a/index.html
+++ b/index.html
@@ -596,8 +596,8 @@
     });
 
     
-    function skeleton(el, count = 3) { el.innerHTML = Array.from({ length: count }, () => '<div class="skeleton"></div>').join(''); }
-    function emptyState(el) { el.innerHTML = '<div class="empty">No fixtures available today</div>'; }
+    function skeleton(el, count = 3) { if (!el) return; el.innerHTML = Array.from({ length: count }, () => '<div class="skeleton"></div>').join(''); }
+    function emptyState(el) { if (!el) return; el.innerHTML = '<div class="empty">No fixtures available today</div>'; }
 
     function parseCSV(text) {
       const rows = [];
@@ -618,10 +618,24 @@
     const csvCache = new Map();
     async function fetchCsv(url) {
       if (csvCache.has(url)) return csvCache.get(url);
-      const promise = fetch(url, { cache: 'force-cache' }).then((response) => {
-        if (!response.ok) throw new Error(`Failed to fetch CSV: ${response.status}`);
-        return response.text();
-      });
+      const candidateUrls = [url, `${url}&cachebust=${Date.now()}`];
+      const promise = (async () => {
+        let lastError = null;
+        for (const candidate of candidateUrls) {
+          try {
+            console.info('[MCPredict] CSV fetch started', candidate);
+            const response = await fetch(candidate, { cache: 'no-store' });
+            if (!response.ok) throw new Error(`Failed to fetch CSV: ${response.status}`);
+            const text = await response.text();
+            console.info('[MCPredict] CSV fetch succeeded', candidate, 'bytes:', text.length);
+            return text;
+          } catch (error) {
+            console.warn('[MCPredict] CSV fetch failed', candidate, error);
+            lastError = error;
+          }
+        }
+        throw lastError || new Error('Failed to fetch CSV');
+      })();
       csvCache.set(url, promise);
       return promise;
     }
@@ -732,6 +746,7 @@
           modelPrice: 3,
           value: 4
         });
+        console.info('[MCPredict] Homepage rows parsed', { bestValue: bestValueRows.length, highChance: highChanceRows.length, bestValueTarget: !!bestValueEl, highChanceTarget: !!highChanceEl });
         renderPickCards(bestValueEl, bestValueRows, 'value');
         renderPickCards(highChanceEl, highChanceRows, 'confidence');
       } catch (e) { emptyState(bestValueEl); emptyState(highChanceEl); }
@@ -765,6 +780,7 @@
         const remainingDuration = Math.max(0, 3000 - elapsed);
         animateNumberRoll(totalGamesEl, totalGamesAnalysed, remainingDuration);
         const categories = extractBestPerformingCategories(rows);
+        console.info('[MCPredict] WhatsHot parsed', { rows: rows.length, categories: categories.length, containerFound: !!el, totalGamesFound: !!totalGamesEl });
         if (!categories.length) {
           return emptyState(el);
         }


### PR DESCRIPTION
### Motivation
- The homepage lost live Google Sheets data after a recent desktop/navigation/layout update, leaving placeholders instead of populated cards and stats.  
- Investigation showed the loader was brittle to non-OK fetch responses and stale cached responses and lacked diagnostics and defensive DOM guards, making failures look like a selector/DOM regression.  
- The goal was to restore live data rendering while keeping the new layout and navigation unchanged.

### Description
- Hardened CSV fetching in the homepage script by switching to `cache: 'no-store'`, adding a cache-busted retry (`${url}&cachebust=…`), and emitting console diagnostics for fetch start/success/failure.  
- Added defensive null-checks to `skeleton` and `emptyState` so missing/renamed containers no longer throw and abort other section rendering.  
- Added targeted `console.info` diagnostics in `loadHomepageSections` and `loadWhatsHot` to log parsed row counts and whether expected target containers were found.  
- Kept all navigation/layout markup and behavior intact and limited changes to the inline homepage JS in `index.html` (fetch/caching, logging, and safe DOM guards).

### Testing
- Static file inspection and diffs (`sed`, `rg`, `diff`) were run against `index.html` and completed successfully to verify the script edits were applied.  
- HTTP checks against the published Google Sheets CSV URLs were run with `curl` and `curl -I`, showing `403 Forbidden` / no-response from this runner environment (network-side restriction observed in CI/runtime), which motivated adding a cache-busted retry and fetch diagnostics; these checks executed and returned the noted HTTP status.  
- Local runtime validations (searches for CSV constants and affected IDs via `rg`) executed successfully and confirmed selectors (`totalGamesAnalysedValue`, `whatsHotContent`, `bestValueContent`, `highChanceContent`) remain present and are targeted by the updated script.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0512df74832f97906682b9f24ccd)