### PR TITLE
Improve empty-state handling for homepage daily pick sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,7 +402,8 @@
     setMobileFooterActiveState();
 
     function skeleton(el, count = 3) { el.innerHTML = Array.from({ length: count }, () => '<div class="skeleton"></div>').join(''); }
-    function emptyState(el) { el.innerHTML = '<div class="empty">No fixtures available today</div>'; }
+    const DAILY_PICKS_EMPTY_MESSAGE = 'No fixtures available. Check again later — weekend fixtures are usually available from 16:00 UK time on Friday.';
+    function emptyState(el, message = 'No fixtures available today') { el.innerHTML = `<div class="empty">${message}</div>`; }
 
     function parseCSV(text) {
       const rows = [];
@@ -433,6 +434,11 @@
 
     function cleanCell(value) {
       return (value || '').trim();
+    }
+
+    function isInvalidDailyPickCell(value) {
+      const normalized = cleanCell(value).toLowerCase();
+      return !normalized || normalized === '#n/a' || normalized === 'undefined' || normalized === 'null' || normalized === 'nan';
     }
 
     function animateNumberRoll(element, finalValue, duration = 3000) {
@@ -473,7 +479,15 @@
           confidence: columnMap.confidence !== undefined ? cleanCell(row[columnMap.confidence]) : undefined,
           value: columnMap.value !== undefined ? cleanCell(row[columnMap.value]) : undefined
         }))
-        .filter(item => item.fixture);
+        .filter((item) => {
+          const baseValid = !isInvalidDailyPickCell(item.fixture)
+            && !isInvalidDailyPickCell(item.bookiePrice)
+            && !isInvalidDailyPickCell(item.modelPrice);
+          if (!baseValid) return false;
+          if (columnMap.confidence !== undefined) return !isInvalidDailyPickCell(item.confidence);
+          if (columnMap.value !== undefined) return !isInvalidDailyPickCell(item.value);
+          return true;
+        });
     }
 
     function getValueBadgeContent(value) {
@@ -507,7 +521,7 @@
     }
 
     function renderPickCards(el, rows, type) {
-      if (!rows.length) return emptyState(el);
+      if (!rows.length) return emptyState(el, DAILY_PICKS_EMPTY_MESSAGE);
       el.innerHTML = `<div class="pick-list">${rows.map((r) => `
         <article class="pick-card">
           <div class="pick-title">${r.fixture || '-'}</div>


### PR DESCRIPTION
### Motivation
- The daily picks sections on the homepage were rendering broken placeholder values like `#N/A`, `undefined`, `null`, `NaN` and blank fields when the Google Sheet had no valid fixtures. 
- Replace the broken cards with a clear, themed empty-state message while preserving normal rendering when valid picks exist.

### Description
- Added a `DAILY_PICKS_EMPTY_MESSAGE` constant and updated the `emptyState` helper to accept a custom message for the daily picks panels. 
- Implemented `isInvalidDailyPickCell` to detect blank and placeholder/error-like values and treat them as invalid. 
- Strengthened `extractFixedRangeRows` to filter out rows where key fields (`fixture`, `bookiePrice`, `modelPrice` and `value`/`confidence` depending on the section) are missing or invalid. 
- Made `renderPickCards` return the dedicated empty-state message when no valid rows remain, leaving section titles and the "See all" buttons intact and reusing existing `.empty` styling.

### Testing
- Ran a targeted search to confirm affected sections are present with `rg -n "Top Value|Highest Probability|daily|#N/A|See all|fixtures" index.html` and inspected the updated areas in `index.html`; both checks succeeded. 
- Reviewed the output diff with `git diff -- index.html` to verify the exact changes to `extractFixedRangeRows`, `renderPickCards`, and the new helpers; the diff matched the intended scope and passed review. 
- No automated unit tests exist for this page-level logic, and no runtime errors were produced by the script changes during static inspection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd88313080832fa5d95fe43bade3ef)