### PR TITLE
Make header sticky, left-align brand and apply new header to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MC Predict</title>
+  <link rel="stylesheet" href="/style.css" />
   <style>
     :root {
       --bg: #111214;
@@ -25,17 +26,11 @@
     }
     .container { max-width: 1120px; margin: 0 auto; padding: 12px 14px 34px; }
 
-    .header {
-      position: sticky; top: 10px; z-index: 20;
-      border: 1px solid var(--border); border-radius: 16px;
-      padding: 10px 12px; background: rgba(20,22,26,.95);
-      box-shadow: var(--shadow); backdrop-filter: blur(8px);
-      display:flex; align-items:center; justify-content:space-between; gap:12px;
-    }
-    .brand { display:flex; align-items:center; gap:10px; min-width:0; text-decoration:none; color:inherit; }
-    .brand img { width:40px; height:40px; border-radius:10px; object-fit:contain; background:#15171a; }
-    .brand h1 { margin:0; font-size:1rem; letter-spacing:.08em; }
-    .brand p { margin:2px 0 0; color:var(--muted); font-size:.73rem; }
+    .header { margin-bottom: 16px; }
+    .brand-copy { min-width: 0; display: grid; }
+    .brand h1 { margin:0; font-size:1rem; letter-spacing:.08em; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .brand p { margin:2px 0 0; color:var(--muted); font-size:.73rem; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .menu-btn { margin-left:auto; }
     .menu-btn, .close-btn {
       background: transparent; color: var(--text); border: 1px solid var(--border);
       width: 42px; height: 42px; border-radius: 12px; cursor: pointer;
@@ -222,11 +217,11 @@
 </head>
 <body>
   <div class="container">
-    <header class="header">
+    <header class="header standard-header">
       <a class="brand" href="/">
         <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
-        <div>
-          <h1>MCPredict</h1>
+        <div class="brand-copy">
+          <h1>MC PREDICT</h1>
           <p>Data-driven Football predictions</p>
         </div>
       </a>

--- a/style.css
+++ b/style.css
@@ -711,11 +711,11 @@ body.cheltenham iframe {
 
 /* Standard MCPredict shared navigation */
 .site-shell{max-width:1120px;margin:0 auto;padding:12px 14px 34px;}
-.site-header{position:sticky;top:10px;z-index:20;border:1px solid #2f333a;border-radius:16px;padding:10px 12px;background:rgba(20,22,26,.95);box-shadow:0 10px 30px rgba(0,0,0,.35);backdrop-filter:blur(8px);display:flex;align-items:center;justify-content:space-between;gap:12px}
+.site-header{position:sticky;top:0;z-index:120;border:1px solid rgba(47,51,58,.9);border-radius:0;padding:10px 14px;background:rgba(17,18,20,.96);box-shadow:0 10px 24px rgba(0,0,0,.28);backdrop-filter:blur(8px);display:flex;align-items:center;justify-content:space-between;gap:12px}
 .brand{display:flex;align-items:center;gap:10px;min-width:0;text-decoration:none;color:inherit}
 .brand img{width:40px;height:40px;border-radius:10px;object-fit:contain;background:#15171a}
-.brand h1{margin:0;font-size:1rem;letter-spacing:.08em}
-.brand p{margin:2px 0 0;color:#9ba3af;font-size:.73rem}
+.brand h1{margin:0;font-size:1rem;letter-spacing:.08em;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.brand p{margin:2px 0 0;color:#9ba3af;font-size:.73rem;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .menu-btn,.close-btn{background:transparent;color:#f3f4f6;border:1px solid #2f333a;width:42px;height:42px;border-radius:12px;cursor:pointer;display:grid;place-items:center}
 .menu-overlay{position:fixed;inset:0;z-index:100;background:rgba(8,9,11,.95);transform:translateX(100%);transition:transform .3s ease;display:flex;flex-direction:column;padding:18px}
 .menu-overlay.open{transform:translateX(0)}
@@ -731,13 +731,13 @@ body.cheltenham iframe {
 /* Standard header + burger menu */
 .standard-header {
   position: sticky;
-  top: 10px;
-  z-index: 20;
-  border: 1px solid #2f333a;
-  border-radius: 16px;
-  padding: 10px 12px;
-  background: rgba(20,22,26,.95);
-  box-shadow: 0 10px 30px rgba(0,0,0,.35);
+  top: 0;
+  z-index: 120;
+  border: 1px solid rgba(47,51,58,.9);
+  border-radius: 0;
+  padding: 10px 14px;
+  background: rgba(17,18,20,.96);
+  box-shadow: 0 10px 24px rgba(0,0,0,.28);
   backdrop-filter: blur(8px);
   display:flex;
   align-items:center;
@@ -745,10 +745,12 @@ body.cheltenham iframe {
   gap:12px;
   margin-bottom: 16px;
 }
-.standard-header .brand{display:flex;align-items:center;gap:10px;min-width:0;text-decoration:none;color:inherit}
+.standard-header .brand{display:flex;align-items:center;gap:10px;min-width:0;flex:1 1 auto;text-decoration:none;color:inherit}
 .standard-header .brand img{width:40px;height:40px;border-radius:10px;object-fit:contain;background:#15171a}
-.standard-header .brand h1{margin:0;font-size:1rem;letter-spacing:.08em;text-transform:none}
-.standard-header .brand p{margin:2px 0 0;color:#9ba3af;font-size:.73rem}
+.standard-header .brand h1{margin:0;font-size:1rem;letter-spacing:.08em;text-transform:none;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.standard-header .brand p{margin:2px 0 0;color:#9ba3af;font-size:.73rem;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.standard-header .brand-copy{min-width:0;display:grid}
+.standard-header .menu-btn{margin-left:auto;flex:0 0 auto}
 .menu-btn,.close-btn{background:transparent;color:#f3f4f6;border:1px solid #2f333a;width:42px;height:42px;border-radius:12px;cursor:pointer;display:grid;place-items:center}
 .menu-btn svg,.close-btn svg{width:20px;height:20px}
 .menu-overlay{position:fixed;inset:0;z-index:100;background:rgba(8,9,11,.95);transform:translateX(100%);transition:transform .3s ease;display:flex;flex-direction:column;padding:18px}


### PR DESCRIPTION
### Motivation
- Replace the old pill-style homepage header with the newer flat header used across the site and ensure the header remains visible while scrolling. 
- Left-align the grouped brand block (logo + title + subtitle) and pin the burger menu to the far right so the header reads as a balanced professional title bar on all viewports. 

### Description
- Updated shared stylesheet `style.css` to make the shared header sticky at the top (`position: sticky; top: 0`) with a higher `z-index`, dark translucent background, subtle shadow, and removed pill border-radius so the header feels deliberate when sticky. 
- Added truncation-safe and flex rules (`min-width: 0`, `flex: 1 1 auto`, `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`) to the brand and text so title/subtitle left-align and shrink safely on small screens. 
- Ensured the burger/menu button is placed on the far right by adding `margin-left: auto` and `flex: 0 0 auto` to the menu button so logo + copy remain grouped on the left. 
- Applied the shared `standard-header` pattern to the homepage by linking `style.css` in `index.html`, swapping the homepage header to `class="header standard-header"`, adding a `brand-copy` wrapper and updating the displayed title to match the site header style, while leaving the existing menu overlay markup and behavior intact. 

### Testing
- Searched the repo to confirm header classes and occurrences using `rg` and inspected the modified files, which completed successfully. 
- Verified the file diffs and header snippets using local inspection commands (`git diff`/file reads via `sed` and `nl`) to confirm the expected CSS and HTML changes were applied successfully. 
- No automated browser UI test suite was executed as part of this change; manual visual verification in target breakpoints is recommended to confirm layout and interactions (menu open/close, no horizontal overflow).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd8dff9c54832f98e1b9ab04c1cbb7)