### PR TITLE
Unify site header to flat sticky design across site shells

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     }
     .container { max-width: 1120px; margin: 0 auto; padding: 12px 14px 34px; }
 
-    .header { margin-bottom: 16px; position:sticky; top:0; z-index:1200; background:rgba(17,18,20,.94); backdrop-filter:blur(8px); border:1px solid rgba(47,51,58,.9); border-radius:16px; padding:10px 12px; box-shadow:0 8px 18px rgba(0,0,0,.35);} 
+    .header { margin: 0 0 16px; position:sticky; top:0; z-index:2000; width:100%; background:#18181a; border:0; border-bottom:1px solid rgba(255,255,255,.06); border-radius:0; padding:14px 16px; box-shadow:none; } 
     .brand-copy { min-width: 0; display: grid; }
     .brand h1 { margin:0; font-size:1rem; letter-spacing:.08em; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
     .brand p { margin:2px 0 0; color:var(--muted); font-size:.73rem; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
@@ -39,7 +39,7 @@
     .menu-btn svg, .close-btn svg { width: 20px; height:20px; }
 
     .menu-overlay {
-      position: fixed; inset:0; z-index: 100;
+      position: fixed; inset:0; z-index: 3000;
       background: rgba(8,9,11,.95);
       transform: translateX(100%); transition: transform .3s ease;
       display:flex; flex-direction:column; padding:18px;

--- a/style.css
+++ b/style.css
@@ -845,3 +845,55 @@ body.cheltenham iframe {
 .menu-links{display:grid;gap:10px;}
 .menu-links a{text-decoration:none;color:#f3f4f6;border:1px solid #2f333a;background:#1a1c1f;border-radius:14px;padding:14px;font-weight:600;}
 .menu-links a.active{border-color:rgba(247,147,26,.7);color:#f7931a;}
+
+
+/* Unified flat sticky header (single source of truth) */
+.standard-header,
+.home-topbar,
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 2000;
+  width: 100%;
+  margin: 0 0 16px;
+  padding: 14px 16px;
+  border: 0;
+  border-bottom: 1px solid rgba(255,255,255,.06);
+  border-radius: 0;
+  background: #18181a;
+  box-shadow: none;
+  backdrop-filter: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.standard-header .brand,
+.brand-header-link,
+.site-header .brand {
+  display:flex;
+  align-items:center;
+  gap:12px;
+  min-width:0;
+  flex:1 1 auto;
+  text-decoration:none;
+}
+.standard-header .brand-copy,
+.topbar-title {
+  min-width:0;
+  display:grid;
+  text-align:left;
+}
+.standard-header .brand h1,
+.brand-header-link .topbar-title h1,
+.standard-header .brand-copy h1 {font-size:1rem;}
+.standard-header .brand p,
+.brand-header-link .topbar-title span,
+.standard-header .brand-copy p {font-size:.73rem;}
+.menu-btn,.close-btn{margin-left:auto;flex:0 0 auto;}
+.menu-overlay{z-index:3000;}
+@media (max-width:430px){
+  .standard-header, .home-topbar, .site-header{padding:12px;}
+  .standard-header .brand h1, .brand-header-link .topbar-title h1, .standard-header .brand-copy h1{font-size:.96rem;}
+  .standard-header .brand p, .brand-header-link .topbar-title span, .standard-header .brand-copy p{font-size:.7rem;}
+}


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth flat header across the entire site to replace inconsistent pill/card header styles. 
- Ensure the header is full-width, left-aligned (logo + title/subtitle), burger on the far right, and sticky with a solid dark background. 
- Keep existing page functionality (data loading, nav links, burger behavior) intact while fixing visual/layout inconsistencies. 

### Description
- Replaced the pill-style header inline CSS in `index.html` with a full-width flat sticky header rule (uses `position: sticky`, `top: 0`, dark background, no rounded container, increased `z-index`).
- Increased the menu overlay stacking so the burger/menu remains clickable above content by adjusting the overlay `z-index` in `index.html`.
- Added a shared CSS override block at the end of `style.css` implementing the unified flat sticky header for `.standard-header`, `.home-topbar`, and `.site-header`, including left-aligned brand/title, `min-width: 0` behaviours, right-aligned menu button, and responsive tweaks for narrow screens.
- No JavaScript or page-specific data-loading logic was altered, and existing menu links/behavior are preserved.

### Testing
- Searched the codebase for header patterns with `rg` to verify pages that use the shared header and confirmed changes target the shared shells, which succeeded.
- Reviewed changes with `git diff -- index.html style.css` and inspected file excerpts with `nl`/`sed` to confirm the new CSS block and inline updates, which succeeded.
- Verified working tree and committed the changes with `git status --short` and `git commit` (commit message: `Unify site header to flat sticky layout across shared shells`), which succeeded.
- Created the PR payload via the existing `make_pr` helper to publish this change, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd968f284c832faf053b8ddeb512b1)