### PR TITLE
Redesign prediction table area into mobile-first betting selection UI

### DIFF
--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -69,9 +69,10 @@
         <div class="prediction-filter-row" id="result-filters"></div>
       </div>
 
-      <p class="prediction-note">Bookmaker and model prices are shown in the price columns.</p>
+      <p class="prediction-note">Bookmaker and model prices are shown side-by-side with model edge strength for each selection.</p>
 
-      <div id="sheet-data" class="prediction-table-wrap"></div>
+      <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="sheet-data"></div>
     </section>
   </div>
 
@@ -84,7 +85,6 @@
 
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=1040433174&single=true&output=csv";
-    const secondFilterLabel = "predicted result";
     let headerRow = [];
     let dataRows = [];
     const activeDayFilters = new Set();
@@ -94,6 +94,14 @@
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
     function sanitize(v) { return (v || "").trim(); }
+
+    function edgeBand(value) {
+      const n = Number.parseFloat(sanitize(value));
+      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
+      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
+      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
+      return { label: "Small", cls: "prediction-edge-small" };
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -119,8 +127,7 @@
       });
 
       Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
-        const label = result.replace(/\b\w/g, c => c.toUpperCase()).toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
-        resultWrap.appendChild(createFilterButton(label, btn => {
+        resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
           renderTable();
@@ -136,13 +143,23 @@
 
     function renderTable() {
       const container = document.getElementById("sheet-data");
+      const summary = document.getElementById("results-summary");
       const filtered = dataRows.filter(rowMatches);
+      summary.innerHTML = `<div class="prediction-summary-count">Showing ${filtered.length} selections</div><div>Latest model data</div>`;
       if (!headerRow.length) { container.innerHTML = "<p class='prediction-empty'>No table header found in source data.</p>"; return; }
       if (!filtered.length) { container.innerHTML = "<p class='prediction-empty'>No selections match the active filters.</p>"; return; }
-      let html = "<table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
-      filtered.forEach(row => { html += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
-      html += "</tbody></table>";
-      container.innerHTML = html;
+
+      let cards = "<div class='prediction-card-list prediction-mobile-only'>";
+      filtered.forEach(row => {
+        const edge = edgeBand(row[8]);
+        cards += `<article class='prediction-card'><div class='prediction-card-top'><div>${sanitize(row[0])} • ${sanitize(row[1])}</div><span class='prediction-badge'>${sanitize(row[5])}</span></div><div class='prediction-fixture'><span>${sanitize(row[2])}</span><span class='prediction-versus'>v</span><span>${sanitize(row[3])}</span></div><div class='prediction-card-grid'><div class='prediction-odds-box'><div class='prediction-box-label'>Bookmaker Price</div><div class='prediction-box-value'>${sanitize(row[6])}</div></div><div class='prediction-odds-box'><div class='prediction-box-label'>Model Price</div><div class='prediction-box-value'>${sanitize(row[7])}</div></div><div class='prediction-edge-box' style='grid-column:1 / -1;'><div class='prediction-box-label'>Value / Edge Strength</div><div class='prediction-box-value ${edge.cls}'>${edge.label}</div></div></div></article>`;
+      });
+      cards += "</div>";
+
+      let table = "<div class='prediction-table-wrap prediction-desktop-only'><table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
+      filtered.forEach(row => { table += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
+      table += "</tbody></table></div>";
+      container.innerHTML = cards + table;
     }
 
     async function loadCSV() {

--- a/hda-value.html
+++ b/hda-value.html
@@ -69,9 +69,10 @@
         <div class="prediction-filter-row" id="result-filters"></div>
       </div>
 
-      <p class="prediction-note">Bookmaker and model prices are shown in the price columns.</p>
+      <p class="prediction-note">Bookmaker and model prices are shown side-by-side with model edge strength for each selection.</p>
 
-      <div id="sheet-data" class="prediction-table-wrap"></div>
+      <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="sheet-data"></div>
     </section>
   </div>
 
@@ -84,7 +85,6 @@
 
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=772292951&single=true&output=csv";
-    const secondFilterLabel = "predicted result";
     let headerRow = [];
     let dataRows = [];
     const activeDayFilters = new Set();
@@ -94,6 +94,14 @@
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
     function sanitize(v) { return (v || "").trim(); }
+
+    function edgeBand(value) {
+      const n = Number.parseFloat(sanitize(value));
+      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
+      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
+      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
+      return { label: "Small", cls: "prediction-edge-small" };
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -119,8 +127,7 @@
       });
 
       Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
-        const label = result.replace(/\b\w/g, c => c.toUpperCase()).toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
-        resultWrap.appendChild(createFilterButton(label, btn => {
+        resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
           renderTable();
@@ -136,13 +143,23 @@
 
     function renderTable() {
       const container = document.getElementById("sheet-data");
+      const summary = document.getElementById("results-summary");
       const filtered = dataRows.filter(rowMatches);
+      summary.innerHTML = `<div class="prediction-summary-count">Showing ${filtered.length} selections</div><div>Latest model data</div>`;
       if (!headerRow.length) { container.innerHTML = "<p class='prediction-empty'>No table header found in source data.</p>"; return; }
       if (!filtered.length) { container.innerHTML = "<p class='prediction-empty'>No selections match the active filters.</p>"; return; }
-      let html = "<table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
-      filtered.forEach(row => { html += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
-      html += "</tbody></table>";
-      container.innerHTML = html;
+
+      let cards = "<div class='prediction-card-list prediction-mobile-only'>";
+      filtered.forEach(row => {
+        const edge = edgeBand(row[8]);
+        cards += `<article class='prediction-card'><div class='prediction-card-top'><div>${sanitize(row[0])} • ${sanitize(row[1])}</div><span class='prediction-badge'>${sanitize(row[5])}</span></div><div class='prediction-fixture'><span>${sanitize(row[2])}</span><span class='prediction-versus'>v</span><span>${sanitize(row[3])}</span></div><div class='prediction-card-grid'><div class='prediction-odds-box'><div class='prediction-box-label'>Bookmaker Price</div><div class='prediction-box-value'>${sanitize(row[6])}</div></div><div class='prediction-odds-box'><div class='prediction-box-label'>Model Price</div><div class='prediction-box-value'>${sanitize(row[7])}</div></div><div class='prediction-edge-box' style='grid-column:1 / -1;'><div class='prediction-box-label'>Value / Edge Strength</div><div class='prediction-box-value ${edge.cls}'>${edge.label}</div></div></div></article>`;
+      });
+      cards += "</div>";
+
+      let table = "<div class='prediction-table-wrap prediction-desktop-only'><table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
+      filtered.forEach(row => { table += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
+      table += "</tbody></table></div>";
+      container.innerHTML = cards + table;
     }
 
     async function loadCSV() {

--- a/style.css
+++ b/style.css
@@ -868,33 +868,50 @@ body.home .table-container table {
 
 /* Prediction pages redesign */
 .prediction-page { background: radial-gradient(circle at top, #3c404a 0%, #2b2d34 38%, #22242b 100%); }
-.prediction-shell { width: min(100%, 1040px); margin: 0 auto; padding-bottom: 110px; }
+.prediction-shell { width: min(100%, 1100px); margin: 0 auto; padding-bottom: 130px; }
 .prediction-header { margin-bottom: 20px; }
-.prediction-tabs { display:flex; gap:10px; margin: 6px 0 18px; flex-wrap:wrap; }
-.prediction-tab { display:inline-flex; align-items:center; justify-content:center; padding:11px 22px; border-radius:999px; background:#16181f; color:#cfd2d8; font-weight:700; letter-spacing:.08em; text-transform:uppercase; text-decoration:none; box-shadow: inset 0 0 0 1px rgba(255,255,255,.06); }
+.prediction-tabs { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; padding:6px; margin:6px 0 18px; border-radius:18px; background:rgba(18,20,25,.9); border:1px solid rgba(242,159,31,.25); }
+.prediction-tab { display:inline-flex; align-items:center; justify-content:center; padding:12px 14px; border-radius:12px; background:transparent; color:#cfd2d8; font-weight:700; letter-spacing:.03em; text-decoration:none; }
 .prediction-tab:hover { text-decoration:none; color:#fff; }
-.prediction-tab--active { background:#f29f1f; color:#151515; box-shadow: 0 8px 20px rgba(242,159,31,.35); }
-.prediction-panel { background: linear-gradient(120deg, rgba(79,63,40,.95), rgba(63,53,39,.92)); border-radius:24px; padding:18px 12px 16px; box-shadow: 0 18px 36px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.08); }
+.prediction-tab--active { background:linear-gradient(135deg,#f7931a,#f4b244); color:#151515; box-shadow:0 8px 20px rgba(242,159,31,.35); }
+.prediction-panel { background:linear-gradient(145deg, rgba(34,36,43,.95), rgba(24,26,31,.96)); border-radius:24px; padding:18px 12px 20px; box-shadow:0 18px 36px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.08); }
 .prediction-eyebrow { color:#f0b056; font-size:.9rem; letter-spacing:.13em; text-transform:uppercase; margin-bottom:8px; }
 .prediction-title { margin:0 0 8px; color:#f3f3f3; font-size:2rem; line-height:1.1; }
 .prediction-intro,.prediction-note { margin:0 0 14px; color:#d2d2d2; max-width:780px; }
-.prediction-filter-section { margin-bottom:10px; }
-.prediction-filter-label { color:#bfc2c9; font-size:1.25rem; letter-spacing:.1em; text-transform:uppercase; margin-bottom:8px; }
+.prediction-filter-section { margin-bottom:14px; padding:12px; border-radius:16px; background:rgba(255,255,255,.03); border:1px solid rgba(255,255,255,.08); }
+.prediction-filter-label { color:#bfc2c9; font-size:1rem; letter-spacing:.03em; margin-bottom:8px; font-weight:700; }
 .prediction-filter-row { display:flex; flex-wrap:wrap; gap:10px; }
-.prediction-filter-button { border:0; background:#3a3f49; color:#e7e7ea; padding:9px 16px; border-radius:10px; font-weight:700; cursor:pointer; }
-.prediction-filter-button--active { background:#f29f1f; color:#1f1f1f; }
-.prediction-table-wrap { overflow-x:auto; -webkit-overflow-scrolling:touch; margin-top:8px; border-radius:14px; border:1px solid rgba(255,255,255,.1); }
+.prediction-filter-button { border:1px solid rgba(255,255,255,.1); background:#2f333d; color:#e7e7ea; padding:9px 15px; border-radius:999px; font-weight:700; cursor:pointer; }
+.prediction-filter-button--active { background:linear-gradient(135deg,#f7931a,#f4b244); color:#1f1f1f; border-color:transparent; }
+.prediction-results-summary { display:flex; align-items:center; justify-content:space-between; gap:10px; margin:8px 0 10px; padding:12px; border-radius:14px; background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.1); color:#e9eaed; }
+.prediction-summary-count { font-size:1.15rem; font-weight:700; }
+.prediction-table-wrap { overflow-x:auto; -webkit-overflow-scrolling:touch; margin-top:8px; border-radius:14px; border:1px solid rgba(255,255,255,.1); background:#1c1f26; }
 .prediction-table { width:100%; min-width:860px; border-collapse:collapse; font-size:.94rem; }
-.prediction-table th { position:sticky; top:0; z-index:1; background:#f29f1f; color:#222; text-transform:uppercase; font-size:.8rem; padding:7px 8px; }
-.prediction-table td { padding:7px 8px; color:#ececf0; border-bottom:1px solid rgba(255,255,255,.05); }
+.prediction-table th { position:sticky; top:0; z-index:1; background:#262a33; color:#f6f7fa; text-transform:uppercase; font-size:.78rem; letter-spacing:.07em; padding:11px 12px; text-align:left; white-space:nowrap; }
+.prediction-table td { padding:10px 12px; color:#ececf0; border-bottom:1px solid rgba(255,255,255,.05); white-space:nowrap; }
 .prediction-table tbody tr:nth-child(odd) { background: rgba(31,34,42,.86); }
 .prediction-table tbody tr:nth-child(even) { background: rgba(58,60,67,.86); }
-.prediction-empty { margin:0; padding:14px; color:#f1f1f1; background:#2a2d35; border-radius:12px; }
+.prediction-table tbody tr:hover { background:rgba(72,76,88,.86); }
+.prediction-card-list { display:grid; gap:12px; margin-top:8px; }
+.prediction-card { padding:12px; border-radius:16px; background:linear-gradient(145deg,#2a2d35,#1d2027); border:1px solid rgba(255,255,255,.12); }
+.prediction-card-top { display:flex; justify-content:space-between; gap:10px; color:#cfd4dc; font-size:.95rem; margin-bottom:8px; }
+.prediction-badge { display:inline-flex; align-items:center; justify-content:center; padding:7px 12px; border-radius:999px; font-weight:800; color:#121212; background:linear-gradient(135deg,#f7931a,#f4b244); text-transform:uppercase; font-size:.88rem; }
+.prediction-fixture { display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:10px; color:#fff; font-weight:700; font-size:1.5rem; margin-bottom:10px; }
+.prediction-fixture span:last-child { text-align:right; }
+.prediction-versus { color:#f7931a; font-size:1.2rem; }
+.prediction-card-grid { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; }
+.prediction-odds-box,.prediction-edge-box { padding:10px; border-radius:12px; background:#181b22; border:1px solid rgba(255,255,255,.09); }
+.prediction-box-label { color:#afb4be; font-size:.84rem; margin-bottom:4px; }
+.prediction-box-value { color:#f5f6f8; font-weight:700; font-size:1.45rem; line-height:1.1; }
+.prediction-edge-small { color:#8fb8ff; } .prediction-edge-medium { color:#f0b056; } .prediction-edge-strong { color:#76d26f; }
 .prediction-bottom-nav { z-index:1100; }
-
+.prediction-desktop-only { display:none; }
 @media (min-width: 768px) {
   .prediction-shell { padding-bottom: 34px; }
+  .prediction-tabs { max-width:620px; }
   .prediction-panel { padding: 28px; }
   .prediction-title { font-size: 3rem; }
-  .prediction-filter-label { font-size:1.55rem; }
+  .prediction-filter-label { font-size:1.1rem; }
+  .prediction-mobile-only { display:none; }
+  .prediction-desktop-only { display:block; }
 }

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -69,9 +69,10 @@
         <div class="prediction-filter-row" id="result-filters"></div>
       </div>
 
-      <p class="prediction-note">Bookmaker and model prices are shown in the price columns.</p>
+      <p class="prediction-note">Bookmaker and model prices are shown side-by-side with model edge strength for each selection.</p>
 
-      <div id="sheet-data" class="prediction-table-wrap"></div>
+      <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="sheet-data"></div>
     </section>
   </div>
 
@@ -84,7 +85,6 @@
 
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=1035748278&single=true&output=csv";
-    const secondFilterLabel = "prediction";
     let headerRow = [];
     let dataRows = [];
     const activeDayFilters = new Set();
@@ -94,6 +94,14 @@
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
     function sanitize(v) { return (v || "").trim(); }
+
+    function edgeBand(value) {
+      const n = Number.parseFloat(sanitize(value));
+      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
+      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
+      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
+      return { label: "Small", cls: "prediction-edge-small" };
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -119,8 +127,7 @@
       });
 
       Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
-        const label = result.replace(/\b\w/g, c => c.toUpperCase()).toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
-        resultWrap.appendChild(createFilterButton(label, btn => {
+        resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
           renderTable();
@@ -136,13 +143,23 @@
 
     function renderTable() {
       const container = document.getElementById("sheet-data");
+      const summary = document.getElementById("results-summary");
       const filtered = dataRows.filter(rowMatches);
+      summary.innerHTML = `<div class="prediction-summary-count">Showing ${filtered.length} selections</div><div>Latest model data</div>`;
       if (!headerRow.length) { container.innerHTML = "<p class='prediction-empty'>No table header found in source data.</p>"; return; }
       if (!filtered.length) { container.innerHTML = "<p class='prediction-empty'>No selections match the active filters.</p>"; return; }
-      let html = "<table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
-      filtered.forEach(row => { html += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
-      html += "</tbody></table>";
-      container.innerHTML = html;
+
+      let cards = "<div class='prediction-card-list prediction-mobile-only'>";
+      filtered.forEach(row => {
+        const edge = edgeBand(row[8]);
+        cards += `<article class='prediction-card'><div class='prediction-card-top'><div>${sanitize(row[0])} • ${sanitize(row[1])}</div><span class='prediction-badge'>${sanitize(row[5])}</span></div><div class='prediction-fixture'><span>${sanitize(row[2])}</span><span class='prediction-versus'>v</span><span>${sanitize(row[3])}</span></div><div class='prediction-card-grid'><div class='prediction-odds-box'><div class='prediction-box-label'>Bookmaker Price</div><div class='prediction-box-value'>${sanitize(row[6])}</div></div><div class='prediction-odds-box'><div class='prediction-box-label'>Model Price</div><div class='prediction-box-value'>${sanitize(row[7])}</div></div><div class='prediction-edge-box' style='grid-column:1 / -1;'><div class='prediction-box-label'>Value / Edge Strength</div><div class='prediction-box-value ${edge.cls}'>${edge.label}</div></div></div></article>`;
+      });
+      cards += "</div>";
+
+      let table = "<div class='prediction-table-wrap prediction-desktop-only'><table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
+      filtered.forEach(row => { table += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
+      table += "</tbody></table></div>";
+      container.innerHTML = cards + table;
     }
 
     async function loadCSV() {

--- a/uo-value.html
+++ b/uo-value.html
@@ -69,9 +69,10 @@
         <div class="prediction-filter-row" id="result-filters"></div>
       </div>
 
-      <p class="prediction-note">Bookmaker and model prices are shown in the price columns.</p>
+      <p class="prediction-note">Bookmaker and model prices are shown side-by-side with model edge strength for each selection.</p>
 
-      <div id="sheet-data" class="prediction-table-wrap"></div>
+      <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="sheet-data"></div>
     </section>
   </div>
 
@@ -84,7 +85,6 @@
 
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=702828084&single=true&output=csv";
-    const secondFilterLabel = "prediction";
     let headerRow = [];
     let dataRows = [];
     const activeDayFilters = new Set();
@@ -94,6 +94,14 @@
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
     function sanitize(v) { return (v || "").trim(); }
+
+    function edgeBand(value) {
+      const n = Number.parseFloat(sanitize(value));
+      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
+      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
+      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
+      return { label: "Small", cls: "prediction-edge-small" };
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -119,8 +127,7 @@
       });
 
       Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
-        const label = result.replace(/\b\w/g, c => c.toUpperCase()).toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
-        resultWrap.appendChild(createFilterButton(label, btn => {
+        resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
           renderTable();
@@ -136,13 +143,23 @@
 
     function renderTable() {
       const container = document.getElementById("sheet-data");
+      const summary = document.getElementById("results-summary");
       const filtered = dataRows.filter(rowMatches);
+      summary.innerHTML = `<div class="prediction-summary-count">Showing ${filtered.length} selections</div><div>Latest model data</div>`;
       if (!headerRow.length) { container.innerHTML = "<p class='prediction-empty'>No table header found in source data.</p>"; return; }
       if (!filtered.length) { container.innerHTML = "<p class='prediction-empty'>No selections match the active filters.</p>"; return; }
-      let html = "<table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
-      filtered.forEach(row => { html += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
-      html += "</tbody></table>";
-      container.innerHTML = html;
+
+      let cards = "<div class='prediction-card-list prediction-mobile-only'>";
+      filtered.forEach(row => {
+        const edge = edgeBand(row[8]);
+        cards += `<article class='prediction-card'><div class='prediction-card-top'><div>${sanitize(row[0])} • ${sanitize(row[1])}</div><span class='prediction-badge'>${sanitize(row[5])}</span></div><div class='prediction-fixture'><span>${sanitize(row[2])}</span><span class='prediction-versus'>v</span><span>${sanitize(row[3])}</span></div><div class='prediction-card-grid'><div class='prediction-odds-box'><div class='prediction-box-label'>Bookmaker Price</div><div class='prediction-box-value'>${sanitize(row[6])}</div></div><div class='prediction-odds-box'><div class='prediction-box-label'>Model Price</div><div class='prediction-box-value'>${sanitize(row[7])}</div></div><div class='prediction-edge-box' style='grid-column:1 / -1;'><div class='prediction-box-label'>Value / Edge Strength</div><div class='prediction-box-value ${edge.cls}'>${edge.label}</div></div></div></article>`;
+      });
+      cards += "</div>";
+
+      let table = "<div class='prediction-table-wrap prediction-desktop-only'><table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
+      filtered.forEach(row => { table += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
+      table += "</tbody></table></div>";
+      container.innerHTML = cards + table;
     }
 
     async function loadCSV() {


### PR DESCRIPTION
### Motivation
- Convert the existing tabular prediction list into a mobile-first sportsbook-style selection interface while preserving all existing data fields and keeping the top title bar and bottom mobile navigation unchanged. 
- Improve desktop presentation (spacing, sticky header, zebra rows, horizontal scrolling) while reusing shared stylesheet rules rather than inline styles. 
- Make value/edge clearer to users by mapping numeric value logic to human-friendly strength labels (Small / Medium / Strong). 

### Description
- Reworked shared styles in `style.css` to add segmented tab styling, sportsbook chips for filters, a results summary panel, mobile card layouts, desktop table tweaks, and extra bottom padding to avoid the fixed mobile nav. 
- Updated `hda-value.html`, `hda-highchance.html`, `uo-value.html`, and `uo-highchance.html` to inject a `results-summary` region and to replace the single mobile table render with a mobile-only vertical card list plus a desktop-only table using the same dataset. 
- Implemented `edgeBand()` mapping in each page script to convert the existing numeric value column into `Small` / `Medium` / `Strong` labels and CSS classes, and kept bookmaker/model prices and all original fields (day, league, home, away, predicted result, bookmaker price, model price, value) in the UI. 
- Adjusted filter button behavior and labels to use sportsbook-style chips and styled the Best Value / Highest Chance tabs with an orange brand gradient active state. 

### Testing
- Ran repository checks and inspections: `git status --short` and committed the changes successfully (commit created). — succeeded. 
- Verified presence of key modifications with text searches: `rg -n "results-summary|prediction-mobile-only|edgeBand|prediction-tabs"` across updated pages and `style.css` — succeeded. 
- Dumped and reviewed relevant file sections with `nl -ba`/`sed` to confirm the new `edgeBand()` logic, the `renderTable()` mobile/desktop composition, and the CSS block presence in `style.css` — succeeded. 
- Created PR metadata via the `make_pr` helper which completed successfully. — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda7ca1c24832fbb28a7aa97edfd27)