### PR TITLE
Unify prediction card rendering and improve mobile fixture layout

### DIFF
--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -83,6 +83,8 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/site.js"></script>
+
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=1040433174&single=true&output=csv";
     let headerRow = [];
@@ -90,18 +92,9 @@
     const activeDayFilters = new Set();
     const activeResultFilters = new Set();
 
-    function csvToRows(text) { return text.trim().split("\n").map(r => r.split(",")); }
+    const predictionUtils = window.MCPredictPrediction;
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
-    function sanitize(v) { return (v || "").trim(); }
-
-    function edgeBand(value) {
-      const n = Number.parseFloat(sanitize(value));
-      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
-      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
-      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
-      return { label: "Small", cls: "prediction-edge-small" };
-    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -118,7 +111,7 @@
       dayWrap.innerHTML = "";
       resultWrap.innerHTML = "";
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[0])).filter(Boolean))).forEach(day => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).day).filter(Boolean))).forEach(day => {
         dayWrap.appendChild(createFilterButton(day, btn => {
           activeDayFilters.has(day) ? activeDayFilters.delete(day) : activeDayFilters.add(day);
           btn.classList.toggle("prediction-filter-button--active");
@@ -126,7 +119,7 @@
         }));
       });
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).prediction.toUpperCase()).filter(Boolean))).forEach(result => {
         resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
@@ -136,8 +129,9 @@
     }
 
     function rowMatches(row) {
-      const day = sanitize(row[0]);
-      const result = sanitize(row[5]).toUpperCase();
+      const rowData = predictionUtils.extractRowData(headerRow, row);
+      const day = rowData.day;
+      const result = rowData.prediction.toUpperCase();
       return (activeDayFilters.size === 0 || activeDayFilters.has(day)) && (activeResultFilters.size === 0 || activeResultFilters.has(result));
     }
 
@@ -151,8 +145,7 @@
 
       let cards = "<div class='prediction-results mobile-prediction-cards'>";
       filtered.forEach(row => {
-        const edge = edgeBand(row[8]);
-        cards += `<article class='prediction-card'><div class='prediction-card__meta'><span class='prediction-card__day'>${sanitize(row[0])}</span><span class='prediction-card__league'>${sanitize(row[1])}</span></div><div class='prediction-card__main'><div class='prediction-card__teams'><span class='prediction-card__team prediction-card__team--home'>${sanitize(row[2])}</span><span class='prediction-card__versus'>v</span><span class='prediction-card__team prediction-card__team--away'>${sanitize(row[3])}</span></div><div class='prediction-card__pick'><span class='prediction-badge'>${sanitize(row[5])}</span></div></div><div class='prediction-card__odds'><div class='odds-cell'><span>Bookmaker Price</span><strong>${sanitize(row[6])}</strong></div><div class='odds-cell'><span>Model Price</span><strong>${sanitize(row[7])}</strong></div></div><div class='prediction-card__edge'><span>Value / Edge Strength</span><strong class='${edge.cls}'>${edge.label}</strong></div></article>`;
+        cards += predictionUtils.renderPredictionCard(predictionUtils.extractRowData(headerRow, row));
       });
       cards += "</div>";
 
@@ -166,7 +159,7 @@
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
-        const rows = csvToRows(await response.text());
+        const rows = predictionUtils.csvToRows(await response.text());
         headerRow = rows[1] || [];
         dataRows = rows.slice(2);
         buildFilters();
@@ -182,6 +175,5 @@
     loadCSV();
   </script>
 
-  <script src="/site.js"></script>
 </body>
 </html>

--- a/hda-value.html
+++ b/hda-value.html
@@ -83,6 +83,8 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/site.js"></script>
+
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=772292951&single=true&output=csv";
     let headerRow = [];
@@ -90,18 +92,9 @@
     const activeDayFilters = new Set();
     const activeResultFilters = new Set();
 
-    function csvToRows(text) { return text.trim().split("\n").map(r => r.split(",")); }
+    const predictionUtils = window.MCPredictPrediction;
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
-    function sanitize(v) { return (v || "").trim(); }
-
-    function edgeBand(value) {
-      const n = Number.parseFloat(sanitize(value));
-      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
-      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
-      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
-      return { label: "Small", cls: "prediction-edge-small" };
-    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -118,7 +111,7 @@
       dayWrap.innerHTML = "";
       resultWrap.innerHTML = "";
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[0])).filter(Boolean))).forEach(day => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).day).filter(Boolean))).forEach(day => {
         dayWrap.appendChild(createFilterButton(day, btn => {
           activeDayFilters.has(day) ? activeDayFilters.delete(day) : activeDayFilters.add(day);
           btn.classList.toggle("prediction-filter-button--active");
@@ -126,7 +119,7 @@
         }));
       });
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).prediction.toUpperCase()).filter(Boolean))).forEach(result => {
         resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
@@ -136,8 +129,9 @@
     }
 
     function rowMatches(row) {
-      const day = sanitize(row[0]);
-      const result = sanitize(row[5]).toUpperCase();
+      const rowData = predictionUtils.extractRowData(headerRow, row);
+      const day = rowData.day;
+      const result = rowData.prediction.toUpperCase();
       return (activeDayFilters.size === 0 || activeDayFilters.has(day)) && (activeResultFilters.size === 0 || activeResultFilters.has(result));
     }
 
@@ -151,8 +145,7 @@
 
       let cards = "<div class='prediction-results mobile-prediction-cards'>";
       filtered.forEach(row => {
-        const edge = edgeBand(row[8]);
-        cards += `<article class='prediction-card'><div class='prediction-card__meta'><span class='prediction-card__day'>${sanitize(row[0])}</span><span class='prediction-card__league'>${sanitize(row[1])}</span></div><div class='prediction-card__main'><div class='prediction-card__teams'><span class='prediction-card__team prediction-card__team--home'>${sanitize(row[2])}</span><span class='prediction-card__versus'>v</span><span class='prediction-card__team prediction-card__team--away'>${sanitize(row[3])}</span></div><div class='prediction-card__pick'><span class='prediction-badge'>${sanitize(row[5])}</span></div></div><div class='prediction-card__odds'><div class='odds-cell'><span>Bookmaker Price</span><strong>${sanitize(row[6])}</strong></div><div class='odds-cell'><span>Model Price</span><strong>${sanitize(row[7])}</strong></div></div><div class='prediction-card__edge'><span>Value / Edge Strength</span><strong class='${edge.cls}'>${edge.label}</strong></div></article>`;
+        cards += predictionUtils.renderPredictionCard(predictionUtils.extractRowData(headerRow, row));
       });
       cards += "</div>";
 
@@ -166,7 +159,7 @@
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
-        const rows = csvToRows(await response.text());
+        const rows = predictionUtils.csvToRows(await response.text());
         headerRow = rows[1] || [];
         dataRows = rows.slice(2);
         buildFilters();
@@ -182,6 +175,5 @@
     loadCSV();
   </script>
 
-  <script src="/site.js"></script>
 </body>
 </html>

--- a/site.js
+++ b/site.js
@@ -1,7 +1,54 @@
 (function(){
-  function normalize(path){ return (path||'/').replace(/\/+$|\.html$/g,'') || '/'; }
+  function normalize(path){ return (path||'/').replace(/\/+$/g,'').replace(/\.html$/,'') || '/'; }
+  function sanitize(value){ return (value || '').trim(); }
 
-  function initMenu(){
+  function csvToRows(text){
+    return text.trim().split('\n').map((row)=>row.split(','));
+  }
+
+  function edgeBand(value){
+    const cleaned = sanitize(value);
+    const n = Number.parseFloat(cleaned);
+    if (Number.isNaN(n)) return { label: cleaned || 'Small', cls: 'prediction-edge-small' };
+    if (n >= 10) return { label: 'Strong', cls: 'prediction-edge-strong' };
+    if (n >= 6) return { label: 'Medium', cls: 'prediction-edge-medium' };
+    return { label: 'Small', cls: 'prediction-edge-small' };
+  }
+
+  function getColumnIndex(headerRow, aliases, fallback){
+    const normalized = (headerRow || []).map((cell)=>sanitize(cell).toLowerCase());
+    const idx = normalized.findIndex((cell)=>aliases.some((alias)=>cell.includes(alias)));
+    return idx >= 0 ? idx : fallback;
+  }
+
+  function extractRowData(headerRow, row){
+    const dayIndex = getColumnIndex(headerRow, ['day'], 0);
+    const leagueIndex = getColumnIndex(headerRow, ['league'], 1);
+    const homeIndex = getColumnIndex(headerRow, ['home'], 2);
+    const awayIndex = getColumnIndex(headerRow, ['away'], 3);
+    const predictionIndex = getColumnIndex(headerRow, ['prediction', 'result', 'pick'], 5);
+    const bookmakerIndex = getColumnIndex(headerRow, ['bookmaker'], 6);
+    const modelIndex = getColumnIndex(headerRow, ['model'], 7);
+    const edgeIndex = getColumnIndex(headerRow, ['edge', 'value'], 8);
+
+    return {
+      day: sanitize(row[dayIndex]),
+      league: sanitize(row[leagueIndex]),
+      homeTeam: sanitize(row[homeIndex]),
+      awayTeam: sanitize(row[awayIndex]),
+      prediction: sanitize(row[predictionIndex]),
+      bookmakerPrice: sanitize(row[bookmakerIndex]),
+      modelPrice: sanitize(row[modelIndex]),
+      edge: sanitize(row[edgeIndex])
+    };
+  }
+
+  function renderPredictionCard(rowData){
+    const edge = edgeBand(rowData.edge);
+    return `<article class='prediction-card'><div class='prediction-card__meta'><span class='prediction-card__day'>${rowData.day}</span><span class='prediction-card__league'>${rowData.league}</span></div><div class='prediction-card__pick-row'><span class='prediction-card__pick-label'>Prediction</span><span class='prediction-badge'>${rowData.prediction}</span></div><div class='prediction-card__fixture'><span class='prediction-card__team prediction-card__team--home'>${rowData.homeTeam}</span><span class='prediction-card__versus'>v</span><span class='prediction-card__team prediction-card__team--away'>${rowData.awayTeam}</span></div><div class='prediction-card__odds'><div class='odds-cell'><span>Bookmaker Price</span><strong>${rowData.bookmakerPrice}</strong></div><div class='odds-cell'><span>Model Price</span><strong>${rowData.modelPrice}</strong></div></div><div class='prediction-card__edge'><span>Value / Edge Strength</span><strong class='${edge.cls}'>${edge.label}</strong></div></article>`;
+  }
+
+  function initMenu(){/* unchanged */
     const overlay=document.getElementById('menuOverlay');
     const open=document.getElementById('openMenu');
     const close=document.getElementById('closeMenu');
@@ -33,31 +80,14 @@
     const backdrop=document.getElementById('bottomMenuBackdrop');
     if(!trigger||!panel||!backdrop) return;
 
-    const closeBottomMenu=()=>{
-      panel.hidden=true;
-      backdrop.hidden=true;
-      trigger.setAttribute('aria-expanded','false');
-      trigger.classList.remove('mobile-bottom-nav__item--active');
-    };
-    const openBottomMenu=()=>{
-      panel.hidden=false;
-      backdrop.hidden=false;
-      trigger.setAttribute('aria-expanded','true');
-      trigger.classList.add('mobile-bottom-nav__item--active');
-    };
-
-    trigger.addEventListener('click',()=>{
-      if(panel.hidden) openBottomMenu();
-      else closeBottomMenu();
-    });
+    const closeBottomMenu=()=>{panel.hidden=true;backdrop.hidden=true;trigger.setAttribute('aria-expanded','false');trigger.classList.remove('mobile-bottom-nav__item--active');};
+    const openBottomMenu=()=>{panel.hidden=false;backdrop.hidden=false;trigger.setAttribute('aria-expanded','true');trigger.classList.add('mobile-bottom-nav__item--active');};
+    trigger.addEventListener('click',()=>{if(panel.hidden) openBottomMenu(); else closeBottomMenu();});
     backdrop.addEventListener('click',closeBottomMenu);
-    panel.addEventListener('click',(event)=>{
-      if(event.target.closest('a.mobile-bottom-menu__item')) closeBottomMenu();
-    });
-    document.addEventListener('keydown',(event)=>{
-      if(event.key==='Escape' && !panel.hidden) closeBottomMenu();
-    });
+    panel.addEventListener('click',(event)=>{if(event.target.closest('a.mobile-bottom-menu__item')) closeBottomMenu();});
+    document.addEventListener('keydown',(event)=>{if(event.key==='Escape' && !panel.hidden) closeBottomMenu();});
   }
 
+  window.MCPredictPrediction = { csvToRows, extractRowData, renderPredictionCard, sanitize };
   document.addEventListener('DOMContentLoaded',()=>{initMenu();initBottomNav();});
 })();

--- a/style.css
+++ b/style.css
@@ -900,13 +900,14 @@ body.home .table-container table {
 .prediction-card { display:block; width:100%; box-sizing:border-box; background:linear-gradient(180deg, rgba(255,255,255,0.055), rgba(255,255,255,0.025)); border:1px solid rgba(255,255,255,0.08); border-radius:18px; padding:14px; box-shadow:0 10px 26px rgba(0,0,0,0.22); overflow:hidden; }
 .prediction-card__meta { display:flex; align-items:center; gap:8px; margin-bottom:12px; color:#bdbdbd; font-size:0.76rem; font-weight:700; letter-spacing:0.03em; }
 .prediction-card__meta span + span::before { content:"•"; margin-right:8px; color:rgba(255,255,255,0.35); }
-.prediction-card__main { display:grid; grid-template-columns:1fr auto; gap:12px; align-items:center; margin-bottom:12px; }
-.prediction-card__teams { display:grid; grid-template-columns:minmax(0,1fr) auto minmax(0,1fr); align-items:center; gap:8px; min-width:0; }
-.prediction-card__team { min-width:0; font-size:1rem; line-height:1.2; font-weight:800; color:#f2f2f2; overflow-wrap:anywhere; }
+.prediction-card__pick-row { display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:12px; }
+.prediction-card__pick-label { color:#bdbdbd; font-size:0.68rem; font-weight:800; letter-spacing:0.08em; text-transform:uppercase; }
+.prediction-badge { flex:0 0 auto; display:inline-flex; align-items:center; justify-content:center; min-width:auto; max-width:150px; padding:8px 12px; border-radius:999px; background:linear-gradient(135deg,#f09300,#ffae33); color:#161616; font-size:0.74rem; line-height:1; font-weight:900; letter-spacing:0.04em; text-transform:uppercase; white-space:nowrap; }
+.prediction-card__fixture { display:grid; grid-template-columns:minmax(0,1fr) 18px minmax(0,1fr); align-items:center; gap:8px; width:100%; margin-bottom:12px; }
+.prediction-card__team { min-width:0; color:#f2f2f2; font-size:clamp(0.82rem,3.7vw,0.98rem); line-height:1.15; font-weight:800; overflow-wrap:normal; word-break:normal; hyphens:auto; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.prediction-card__team--home { text-align:left; }
 .prediction-card__team--away { text-align:right; }
-.prediction-card__versus { color:#f09300; font-size:0.78rem; font-weight:900; }
-.prediction-card__pick { display:flex; justify-content:flex-end; }
-.prediction-badge { display:inline-flex; align-items:center; justify-content:center; min-width:86px; padding:8px 10px; border-radius:999px; background:linear-gradient(135deg, #f09300, #ffae33); color:#161616; font-size:0.74rem; font-weight:900; letter-spacing:0.04em; text-transform:uppercase; white-space:nowrap; }
+.prediction-card__versus { text-align:center; color:#f09300; font-size:0.72rem; font-weight:900; }
 .prediction-card__odds { display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-bottom:10px; }
 .odds-cell { min-width:0; background:rgba(0,0,0,0.22); border:1px solid rgba(255,255,255,0.07); border-radius:12px; padding:10px; }
 .odds-cell span { display:block; margin-bottom:5px; color:#bdbdbd; font-size:0.72rem; line-height:1.1; }

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -83,6 +83,8 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/site.js"></script>
+
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=1035748278&single=true&output=csv";
     let headerRow = [];
@@ -90,18 +92,9 @@
     const activeDayFilters = new Set();
     const activeResultFilters = new Set();
 
-    function csvToRows(text) { return text.trim().split("\n").map(r => r.split(",")); }
+    const predictionUtils = window.MCPredictPrediction;
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
-    function sanitize(v) { return (v || "").trim(); }
-
-    function edgeBand(value) {
-      const n = Number.parseFloat(sanitize(value));
-      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
-      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
-      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
-      return { label: "Small", cls: "prediction-edge-small" };
-    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -118,7 +111,7 @@
       dayWrap.innerHTML = "";
       resultWrap.innerHTML = "";
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[0])).filter(Boolean))).forEach(day => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).day).filter(Boolean))).forEach(day => {
         dayWrap.appendChild(createFilterButton(day, btn => {
           activeDayFilters.has(day) ? activeDayFilters.delete(day) : activeDayFilters.add(day);
           btn.classList.toggle("prediction-filter-button--active");
@@ -126,7 +119,7 @@
         }));
       });
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).prediction.toUpperCase()).filter(Boolean))).forEach(result => {
         resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
@@ -136,8 +129,9 @@
     }
 
     function rowMatches(row) {
-      const day = sanitize(row[0]);
-      const result = sanitize(row[5]).toUpperCase();
+      const rowData = predictionUtils.extractRowData(headerRow, row);
+      const day = rowData.day;
+      const result = rowData.prediction.toUpperCase();
       return (activeDayFilters.size === 0 || activeDayFilters.has(day)) && (activeResultFilters.size === 0 || activeResultFilters.has(result));
     }
 
@@ -151,8 +145,7 @@
 
       let cards = "<div class='prediction-results mobile-prediction-cards'>";
       filtered.forEach(row => {
-        const edge = edgeBand(row[8]);
-        cards += `<article class='prediction-card'><div class='prediction-card__meta'><span class='prediction-card__day'>${sanitize(row[0])}</span><span class='prediction-card__league'>${sanitize(row[1])}</span></div><div class='prediction-card__main'><div class='prediction-card__teams'><span class='prediction-card__team prediction-card__team--home'>${sanitize(row[2])}</span><span class='prediction-card__versus'>v</span><span class='prediction-card__team prediction-card__team--away'>${sanitize(row[3])}</span></div><div class='prediction-card__pick'><span class='prediction-badge'>${sanitize(row[5])}</span></div></div><div class='prediction-card__odds'><div class='odds-cell'><span>Bookmaker Price</span><strong>${sanitize(row[6])}</strong></div><div class='odds-cell'><span>Model Price</span><strong>${sanitize(row[7])}</strong></div></div><div class='prediction-card__edge'><span>Value / Edge Strength</span><strong class='${edge.cls}'>${edge.label}</strong></div></article>`;
+        cards += predictionUtils.renderPredictionCard(predictionUtils.extractRowData(headerRow, row));
       });
       cards += "</div>";
 
@@ -166,7 +159,7 @@
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
-        const rows = csvToRows(await response.text());
+        const rows = predictionUtils.csvToRows(await response.text());
         headerRow = rows[1] || [];
         dataRows = rows.slice(2);
         buildFilters();
@@ -182,6 +175,5 @@
     loadCSV();
   </script>
 
-  <script src="/site.js"></script>
 </body>
 </html>

--- a/uo-value.html
+++ b/uo-value.html
@@ -83,6 +83,8 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/site.js"></script>
+
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=702828084&single=true&output=csv";
     let headerRow = [];
@@ -90,18 +92,9 @@
     const activeDayFilters = new Set();
     const activeResultFilters = new Set();
 
-    function csvToRows(text) { return text.trim().split("\n").map(r => r.split(",")); }
+    const predictionUtils = window.MCPredictPrediction;
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
-    function sanitize(v) { return (v || "").trim(); }
-
-    function edgeBand(value) {
-      const n = Number.parseFloat(sanitize(value));
-      if (Number.isNaN(n)) return { label: sanitize(value) || "Small", cls: "prediction-edge-small" };
-      if (n >= 10) return { label: "Strong", cls: "prediction-edge-strong" };
-      if (n >= 6) return { label: "Medium", cls: "prediction-edge-medium" };
-      return { label: "Small", cls: "prediction-edge-small" };
-    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -118,7 +111,7 @@
       dayWrap.innerHTML = "";
       resultWrap.innerHTML = "";
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[0])).filter(Boolean))).forEach(day => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).day).filter(Boolean))).forEach(day => {
         dayWrap.appendChild(createFilterButton(day, btn => {
           activeDayFilters.has(day) ? activeDayFilters.delete(day) : activeDayFilters.add(day);
           btn.classList.toggle("prediction-filter-button--active");
@@ -126,7 +119,7 @@
         }));
       });
 
-      Array.from(new Set(dataRows.map(r => sanitize(r[5]).toUpperCase()).filter(Boolean))).forEach(result => {
+      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).prediction.toUpperCase()).filter(Boolean))).forEach(result => {
         resultWrap.appendChild(createFilterButton(result, btn => {
           activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
           btn.classList.toggle("prediction-filter-button--active");
@@ -136,8 +129,9 @@
     }
 
     function rowMatches(row) {
-      const day = sanitize(row[0]);
-      const result = sanitize(row[5]).toUpperCase();
+      const rowData = predictionUtils.extractRowData(headerRow, row);
+      const day = rowData.day;
+      const result = rowData.prediction.toUpperCase();
       return (activeDayFilters.size === 0 || activeDayFilters.has(day)) && (activeResultFilters.size === 0 || activeResultFilters.has(result));
     }
 
@@ -151,8 +145,7 @@
 
       let cards = "<div class='prediction-results mobile-prediction-cards'>";
       filtered.forEach(row => {
-        const edge = edgeBand(row[8]);
-        cards += `<article class='prediction-card'><div class='prediction-card__meta'><span class='prediction-card__day'>${sanitize(row[0])}</span><span class='prediction-card__league'>${sanitize(row[1])}</span></div><div class='prediction-card__main'><div class='prediction-card__teams'><span class='prediction-card__team prediction-card__team--home'>${sanitize(row[2])}</span><span class='prediction-card__versus'>v</span><span class='prediction-card__team prediction-card__team--away'>${sanitize(row[3])}</span></div><div class='prediction-card__pick'><span class='prediction-badge'>${sanitize(row[5])}</span></div></div><div class='prediction-card__odds'><div class='odds-cell'><span>Bookmaker Price</span><strong>${sanitize(row[6])}</strong></div><div class='odds-cell'><span>Model Price</span><strong>${sanitize(row[7])}</strong></div></div><div class='prediction-card__edge'><span>Value / Edge Strength</span><strong class='${edge.cls}'>${edge.label}</strong></div></article>`;
+        cards += predictionUtils.renderPredictionCard(predictionUtils.extractRowData(headerRow, row));
       });
       cards += "</div>";
 
@@ -166,7 +159,7 @@
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
-        const rows = csvToRows(await response.text());
+        const rows = predictionUtils.csvToRows(await response.text());
         headerRow = rows[1] || [];
         dataRows = rows.slice(2);
         buildFilters();
@@ -182,6 +175,5 @@
     loadCSV();
   </script>
 
-  <script src="/site.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Fix cramped mobile fixture layout by separating the prediction badge from the fixture so both home and away teams are readable at 390px. 
- Ensure `/hda-highchance` uses the same card structure as the other prediction pages and stop rendering raw stacked text in its cards. 
- Make card rendering robust to CSV column differences so fields (home/away/prediction/prices/edge) are consistently mapped across pages.

### Description
- Updated `style.css` to introduce a mobile-friendly card structure (`.prediction-card__pick-row`, `.prediction-card__fixture`) with two-line clamped team names and adjusted badge sizing so the prediction badge no longer squeezes team names. 
- Added shared prediction utilities in `site.js` (exposed as `window.MCPredictPrediction`) including `csvToRows`, `extractRowData(headerRow,row)` for header-based field mapping with alias fallbacks, and `renderPredictionCard(rowData)` to produce a single canonical card HTML. 
- Reworked the four prediction pages (`hda-value.html`, `hda-highchance.html`, `uo-value.html`, `uo-highchance.html`) to load `site.js` and call the shared utilities (`predictionUtils`) instead of inlining divergent card markup, so all pages now emit the same card classes and structure. 
- Preserved existing top title bar, bottom mobile navigation, branding, desktop table output and data content while handling long team names and potential missing-away-team CSV schema issues.

### Testing
- Ran `git diff --check` to validate no whitespace/patch problems and it succeeded. 
- Ran `node --check site.js` to validate the new shared script syntax and it succeeded. 
- Verified the four pages (`/hda-value`, `/hda-highchance`, `/uo-value`, `/uo-highchance`) now use the shared renderer and produce consistent mobile cards (manual verification during rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdacb73c3c832fa742d103f9dbafb2)