### PR TITLE
Fix away team parsing when fixture separator column is present

### DIFF
--- a/site.js
+++ b/site.js
@@ -27,6 +27,8 @@
     const homeIndex = getColumnIndex(headerRow, ['home'], 2);
     const awayIndex = getColumnIndex(headerRow, ['away'], 3);
     const predictionIndex = getColumnIndex(headerRow, ['prediction', 'result', 'pick'], 5);
+    const awayRaw = sanitize(row[awayIndex]);
+    const awayTeam = awayRaw.toLowerCase() === 'v' ? sanitize(row[awayIndex + 1]) : awayRaw;
     const bookmakerIndex = getColumnIndex(headerRow, ['bookmaker'], 6);
     const modelIndex = getColumnIndex(headerRow, ['model'], 7);
     const edgeIndex = getColumnIndex(headerRow, ['edge', 'value'], 8);
@@ -35,7 +37,7 @@
       day: sanitize(row[dayIndex]),
       league: sanitize(row[leagueIndex]),
       homeTeam: sanitize(row[homeIndex]),
-      awayTeam: sanitize(row[awayIndex]),
+      awayTeam,
       prediction: sanitize(row[predictionIndex]),
       bookmakerPrice: sanitize(row[bookmakerIndex]),
       modelPrice: sanitize(row[modelIndex]),


### PR DESCRIPTION
### Motivation
- The `/hda-highchance` feed included a literal `v` fixture separator column that was being interpreted as the `awayTeam` value causing a white "v" to render where the away team name should be. 
- The intent is to keep the UI and static orange `v` separator unchanged while ensuring `awayTeam` comes from the real away-team column in the sheet.

### Description
- Updated the shared row extraction in `site.js` (`extractRowData`) to read `awayRaw` from the resolved away index and, if that cell is exactly `'v'`, use the next column as the actual `awayTeam`. 
- Preserved existing header-detection logic (`getColumnIndex`) so pages with explicit `away` headers continue to work unchanged. 
- Did not change card markup or CSS and left prediction, bookmaker price, model price and edge/value mappings untouched.

### Testing
- Confirmed the change by inspecting the `site.js` diff to ensure only the intended mapping logic was modified (check succeeded). 
- Attempted an automated live CSV fetch from the production sheet to validate mapping against real rows, but the fetch failed due to an outbound tunnel restriction (`403 Forbidden`) in the environment (validation unable to complete). 
- No other automated unit tests exist for this module, and no UI/CSS changes were made so visual CSS regressions are not expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdaecffe64832fb811fd14f9499bfc)