### PR TITLE
Fix /hda-value CSV rendering with header-based mapping, CSV parser, card UI & filters

### DIFF
--- a/hda-value.html
+++ b/hda-value.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
 </head>
-<body class="home prediction-page">
+<body class="home prediction-page hda-value-page">
   <div class="loading-overlay" id="loadingOverlay" aria-live="polite">
     <div class="loading-ball">⚽</div>
     <div class="loading-pitch-line"></div>
@@ -72,7 +72,7 @@
       <p class="prediction-note">Bookmaker and model prices are shown side-by-side with model edge strength for each selection.</p>
 
       <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
-      <div id="sheet-data"></div>
+      <div id="sheet-data" aria-live="polite"></div>
     </section>
   </div>
 
@@ -87,21 +87,75 @@
 
   <script>
     const csvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vR_1dSqKC6BUuykrL9QA5_fwiIEodU3jXBCskHCA7uVU-EYnHusQWZhMFwZXNvk2bFlElmsQHZ3b4n2/pub?gid=772292951&single=true&output=csv";
-    let headerRow = [];
     let dataRows = [];
-    const activeDayFilters = new Set();
-    const activeResultFilters = new Set();
+    let activeDayFilter = null;
+    let activeResultFilter = null;
+    let latestUpdatedLabel = "Latest model data";
 
-    const predictionUtils = window.MCPredictPrediction;
     function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
-    function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
+    function normHeader(value) { return (value || "").trim().toLowerCase().replace(/[\s\-]+/g, "_"); }
+    function clean(value) { return (value || "").trim(); }
 
-    function createFilterButton(text, onClick) {
+    function parseCSV(text) {
+      const rows = [];
+      let row = [];
+      let cell = "";
+      let inQuotes = false;
+      for (let i = 0; i < text.length; i += 1) {
+        const char = text[i];
+        if (char === '"') {
+          if (inQuotes && text[i + 1] === '"') { cell += '"'; i += 1; } else { inQuotes = !inQuotes; }
+        } else if (char === ',' && !inQuotes) {
+          row.push(cell); cell = "";
+        } else if ((char === '\n' || char === '\r') && !inQuotes) {
+          if (char === '\r' && text[i + 1] === '\n') i += 1;
+          row.push(cell); rows.push(row); row = []; cell = "";
+        } else {
+          cell += char;
+        }
+      }
+      if (cell.length || row.length) { row.push(cell); rows.push(row); }
+      return rows.filter(r => r.some(c => clean(c)));
+    }
+
+    function pick(row, mapping, aliases) {
+      for (const alias of aliases) {
+        const idx = mapping[alias];
+        if (idx !== undefined && row[idx] !== undefined) {
+          const value = clean(row[idx]);
+          if (value) return value;
+        }
+      }
+      return "";
+    }
+
+    function edgeText(value) {
+      const t = clean(value);
+      const n = Number.parseFloat(t);
+      if (!Number.isNaN(n)) return n >= 10 ? "Strong" : (n >= 6 ? "Medium" : "Small");
+      return t || "Small";
+    }
+
+    function toCardData(row, mapping) {
+      return {
+        day: pick(row, mapping, ["day", "match_day", "date", "match_date"]),
+        league: pick(row, mapping, ["league", "competition"]),
+        homeTeam: pick(row, mapping, ["home_team", "home", "hometeam"]),
+        awayTeam: pick(row, mapping, ["away_team", "away", "awayteam"]),
+        prediction: pick(row, mapping, ["prediction", "predicted_result", "result", "pick"]),
+        bookiePrice: pick(row, mapping, ["bookie_price", "bookmaker_odds", "bookmaker_price", "bo"]),
+        modelPrice: pick(row, mapping, ["model_price", "model_odds", "model", "mo"]),
+        edgeRaw: pick(row, mapping, ["edge", "value", "value_rating"]),
+        updatedAt: pick(row, mapping, ["updated", "updated_at", "time", "last_updated"])
+      };
+    }
+
+    function createFilterButton(text, active, onClick) {
       const btn = document.createElement("button");
       btn.type = "button";
-      btn.className = "prediction-filter-button";
+      btn.className = `prediction-filter-button${active ? " prediction-filter-button--active" : ""}`;
       btn.textContent = text;
-      btn.addEventListener("click", () => onClick(btn));
+      btn.addEventListener("click", onClick);
       return btn;
     }
 
@@ -110,63 +164,60 @@
       const resultWrap = document.getElementById("result-filters");
       dayWrap.innerHTML = "";
       resultWrap.innerHTML = "";
-
-      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).day).filter(Boolean))).forEach(day => {
-        dayWrap.appendChild(createFilterButton(day, btn => {
-          activeDayFilters.has(day) ? activeDayFilters.delete(day) : activeDayFilters.add(day);
-          btn.classList.toggle("prediction-filter-button--active");
-          renderTable();
-        }));
-      });
-
-      Array.from(new Set(dataRows.map(r => predictionUtils.extractRowData(headerRow, r).prediction.toUpperCase()).filter(Boolean))).forEach(result => {
-        resultWrap.appendChild(createFilterButton(result, btn => {
-          activeResultFilters.has(result) ? activeResultFilters.delete(result) : activeResultFilters.add(result);
-          btn.classList.toggle("prediction-filter-button--active");
-          renderTable();
-        }));
-      });
+      const days = [...new Set(dataRows.map(r => r.day).filter(Boolean))];
+      const results = ["Home Win", "Away Win", "Draw"];
+      days.forEach(day => dayWrap.appendChild(createFilterButton(day, activeDayFilter === day, () => { activeDayFilter = activeDayFilter === day ? null : day; buildFilters(); renderCards(); })));
+      results.forEach(result => resultWrap.appendChild(createFilterButton(result, activeResultFilter === result, () => { activeResultFilter = activeResultFilter === result ? null : result; buildFilters(); renderCards(); })));
     }
 
-    function rowMatches(row) {
-      const rowData = predictionUtils.extractRowData(headerRow, row);
-      const day = rowData.day;
-      const result = rowData.prediction.toUpperCase();
-      return (activeDayFilters.size === 0 || activeDayFilters.has(day)) && (activeResultFilters.size === 0 || activeResultFilters.has(result));
+    function filteredRows() {
+      return dataRows.filter(row => (!activeDayFilter || row.day === activeDayFilter) && (!activeResultFilter || row.prediction.toLowerCase() === activeResultFilter.toLowerCase()));
     }
 
-    function renderTable() {
+    function renderCards() {
       const container = document.getElementById("sheet-data");
       const summary = document.getElementById("results-summary");
-      const filtered = dataRows.filter(rowMatches);
-      summary.innerHTML = `<div class="selection-summary"><strong>Showing ${filtered.length} selections</strong><span>Latest model data</span></div>`;
-      if (!headerRow.length) { container.innerHTML = "<p class='prediction-empty'>No table header found in source data.</p>"; return; }
-      if (!filtered.length) { container.innerHTML = "<p class='prediction-empty'>No selections match the active filters.</p>"; return; }
+      const filtered = filteredRows();
+      summary.innerHTML = `<div class="prediction-status"><div><strong>Showing ${filtered.length} selections</strong><span>${latestUpdatedLabel}</span></div><button type="button" id="clear-filters" class="prediction-clear-btn">Clear filters</button></div>`;
+      document.getElementById("clear-filters").addEventListener("click", () => { activeDayFilter = null; activeResultFilter = null; buildFilters(); renderCards(); });
 
-      let cards = "<div class='prediction-results mobile-prediction-cards'>";
-      filtered.forEach(row => {
-        cards += predictionUtils.renderPredictionCard(predictionUtils.extractRowData(headerRow, row));
-      });
-      cards += "</div>";
+      if (!filtered.length) {
+        container.innerHTML = "<p class='prediction-empty'>No selections match these filters.</p>";
+        return;
+      }
 
-      let table = "<div class='prediction-table-wrap desktop-prediction-table'><table class='prediction-table'><thead><tr>" + headerRow.map(cell => `<th>${cell}</th>`).join("") + "</tr></thead><tbody>";
-      filtered.forEach(row => { table += "<tr>" + row.map(cell => `<td>${cell}</td>`).join("") + "</tr>"; });
-      table += "</tbody></table></div>";
-      container.innerHTML = cards + table;
+      container.innerHTML = `<div class="prediction-results mobile-prediction-cards">${filtered.map(row => `
+        <article class="prediction-card">
+          <div class="prediction-card__meta"><span>📅 ${row.day || "-"}</span><span>${row.league || "-"}</span></div>
+          <div class="prediction-card__pick-row"><span class="prediction-card__pick-label">Prediction</span><span class="prediction-badge">${row.prediction || "-"}</span></div>
+          <div class="prediction-card__fixture"><span class="prediction-card__team prediction-card__team--home">${row.homeTeam || "-"}</span><span class="prediction-card__versus">v</span><span class="prediction-card__team prediction-card__team--away">${row.awayTeam || "-"}</span></div>
+          <div class="prediction-card__odds"><div class="odds-cell"><span>Bookie Price</span><strong>${row.bookiePrice || "-"}</strong></div><div class="odds-cell"><span>Model Price</span><strong>${row.modelPrice || "-"}</strong></div></div>
+          <div class="prediction-card__edge"><span>Edge</span><strong>${edgeText(row.edgeRaw)}</strong></div>
+        </article>
+      `).join("")}</div>`;
     }
 
     async function loadCSV() {
       try {
         const response = await fetch(csvUrl);
-        if (!response.ok) throw new Error("Network error");
-        const rows = predictionUtils.csvToRows(await response.text());
-        headerRow = rows[1] || [];
-        dataRows = rows.slice(2);
+        if (!response.ok) throw new Error(`CSV request failed with status ${response.status}`);
+        const parsed = parseCSV(await response.text());
+        const header = parsed[0] || [];
+        const mapping = {};
+        header.forEach((h, idx) => { mapping[normHeader(h)] = idx; });
+        dataRows = parsed.slice(1).map(row => toCardData(row, mapping)).filter(row => row.homeTeam && row.awayTeam);
+        const first = dataRows[0] || null;
+        latestUpdatedLabel = first?.updatedAt ? `Latest model data • Updated ${first.updatedAt}` : "Latest model data";
+        console.info("CSV loaded successfully");
+        console.info("Rows parsed:", dataRows.length);
+        console.info("Detected headers:", header);
+        console.info("First parsed row:", first);
         buildFilters();
-        renderTable();
+        renderCards();
       } catch (error) {
-        console.error(error);
-        showLoadError();
+        console.error("Failed to load hda-value CSV", error);
+        document.getElementById("results-summary").innerHTML = "";
+        document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load the latest selections. Please try again shortly.</p>";
       } finally {
         hideLoadingOverlay();
       }

--- a/style.css
+++ b/style.css
@@ -928,3 +928,16 @@ body.home .table-container table {
   .mobile-prediction-cards { display:none; }
   .desktop-prediction-table { display:block; }
 }
+
+/* hda-value page scoped layout updates */
+.hda-value-page .prediction-shell { max-width: 1020px; margin-inline: auto; }
+.hda-value-page .prediction-intro { max-width: 760px; }
+.hda-value-page .prediction-status { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px; border:1px solid rgba(255,255,255,.12); border-radius:14px; background:rgba(255,255,255,.03); }
+.hda-value-page .prediction-status strong { display:block; color:#fff; font-size:1.3rem; }
+.hda-value-page .prediction-status span { color:#bfc2c9; font-size:.98rem; }
+.hda-value-page .prediction-clear-btn { border:1px solid rgba(242,159,31,.45); background:rgba(242,159,31,.12); color:#f7a838; border-radius:12px; padding:10px 14px; font-weight:700; cursor:pointer; }
+.hda-value-page .prediction-empty { margin-top:12px; }
+@media (min-width: 960px){
+  .hda-value-page .mobile-prediction-cards { display:flex; }
+  .hda-value-page .desktop-prediction-table { display:none; }
+}


### PR DESCRIPTION
### Motivation
- Restore the live CSV-driven data flow on `/hda-value` after the redesign broke column-to-field mapping and card rendering. 
- Map fields defensively by header name (with normalisation and aliases) so the UI no longer depends on fragile column indexes or treats the visual “v” as data. 
- Provide a mobile-first card layout, working filters, and branded empty/error states while preserving shared header and bottom navigation. 

### Description
- Rewrote the in-page script in `hda-value.html` to fetch the same published Google Sheets CSV URL and replaced fragile parsing with a robust `parseCSV` implementation that handles quoted values and CRLFs. 
- Added header normalisation (`normHeader`) and an alias-based `pick` helper plus `toCardData` to map CSV columns to fields like `day`, `league`, `homeTeam`, `awayTeam`, `prediction`, `bookiePrice`, `modelPrice`, `edgeRaw`, and `updatedAt`; the visual `v` is rendered by the template only. 
- Replaced the old renderer with a card-first `renderCards` flow and implemented dynamic day filters, fixed result filters (`Home Win`, `Away Win`, `Draw`), and a `Clear filters` action; added useful console logs on success and meaningful error handling/fallback UI on failure. 
- Kept navigation/menu intact and scoped layout changes to `.hda-value-page` in `style.css` to centre content on desktop, maintain the dark/orange brand, and enable card-first desktop behaviour without touching other prediction pages. 

### Testing
- Static inspection of the modified files (`hda-value.html`, `style.css`) and diffs were reviewed with `rg`/`sed` to confirm the expected changes were written to the files. 
- Executed an environment `python` snippet using `urllib.request` to try fetching the live CSV which failed due to a network tunnel/proxy `403 Forbidden` in this environment. 
- Executed a `python` snippet using `requests` which failed because the `requests` package is not available in the sandbox environment. 
- Confirmed the script includes the requested console logs (`CSV loaded successfully`, row count, detected headers, first parsed row) and that branded empty/error messages are shown when fetches fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb19334a8832fbe4634d47a5ac1e7)