### PR TITLE
Refine /hda-value fixture card layout and centre stat boxes

### DIFF
--- a/hda-value.html
+++ b/hda-value.html
@@ -188,11 +188,12 @@
 
       container.innerHTML = `<div class="prediction-results mobile-prediction-cards">${filtered.map(row => `
         <article class="prediction-card">
-          <div class="prediction-card__meta"><span>📅 ${row.day || "-"}</span><span>${row.league || "-"}</span></div>
-          <div class="prediction-card__pick-row"><span class="prediction-card__pick-label">Prediction</span><span class="prediction-badge">${row.prediction || "-"}</span></div>
+          <div class="prediction-card__top">
+            <div class="prediction-card__meta"><span>${row.day || "-"}</span><span>${row.league || "-"}</span></div>
+            <div class="prediction-card__pick-row"><span class="prediction-card__pick-label">Prediction</span><span class="prediction-badge">${row.prediction || "-"}</span></div>
+          </div>
           <div class="prediction-card__fixture"><span class="prediction-card__team prediction-card__team--home">${row.homeTeam || "-"}</span><span class="prediction-card__versus">v</span><span class="prediction-card__team prediction-card__team--away">${row.awayTeam || "-"}</span></div>
-          <div class="prediction-card__odds"><div class="odds-cell"><span>Bookie Price</span><strong>${row.bookiePrice || "-"}</strong></div><div class="odds-cell"><span>Model Price</span><strong>${row.modelPrice || "-"}</strong></div></div>
-          <div class="prediction-card__edge"><span>Edge</span><strong>${edgeText(row.edgeRaw)}</strong></div>
+          <div class="prediction-card__stats"><div class="stat-cell"><span>Bookie Price</span><strong>${row.bookiePrice || "-"}</strong></div><div class="stat-cell"><span>Model Price</span><strong>${row.modelPrice || "-"}</strong></div><div class="stat-cell"><span>Value</span><strong>${edgeText(row.edgeRaw)}</strong></div></div>
         </article>
       `).join("")}</div>`;
     }

--- a/style.css
+++ b/style.css
@@ -941,3 +941,18 @@ body.home .table-container table {
   .hda-value-page .mobile-prediction-cards { display:flex; }
   .hda-value-page .desktop-prediction-table { display:none; }
 }
+
+/* hda-value fixture card refinement */
+.hda-value-page .prediction-card__top { display:flex; align-items:flex-start; justify-content:space-between; gap:10px; margin-bottom:12px; }
+.hda-value-page .prediction-card__meta { margin-bottom:0; }
+.hda-value-page .prediction-card__pick-row { margin-bottom:0; justify-content:flex-end; }
+.hda-value-page .prediction-card__pick-label { display:none; }
+.hda-value-page .prediction-badge { max-width:unset; }
+.hda-value-page .prediction-card__fixture { grid-template-columns:minmax(0,1fr) 28px minmax(0,1fr); gap:12px; margin-bottom:14px; }
+.hda-value-page .prediction-card__team { font-size:clamp(.8rem,3.3vw,.96rem); line-height:1.2; }
+.hda-value-page .prediction-card__versus { font-size:.9rem; letter-spacing:.02em; }
+.hda-value-page .prediction-card__stats { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; }
+.hda-value-page .stat-cell { min-width:0; background:rgba(0,0,0,0.22); border:1px solid rgba(255,255,255,0.07); border-radius:12px; padding:10px 8px; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center; }
+.hda-value-page .stat-cell span { display:block; margin-bottom:5px; color:#bdbdbd; font-size:.7rem; line-height:1.1; }
+.hda-value-page .stat-cell strong { color:#f2f2f2; font-size:.96rem; font-weight:900; font-variant-numeric:tabular-nums; text-transform:uppercase; text-align:center; }
+.hda-value-page .stat-cell:last-child strong { color:#ffae33; }


### PR DESCRIPTION
### Motivation
- Improve matchup readability and spacing so long team names don’t feel cramped and the orange “v” sits as a clear separator. 
- Move the prediction pill into the card header (top-right) to separate it from the team names and match the visual hierarchy in the mock-up. 
- Rename the `Edge` stat to `Value`, centre-align stat titles and prices, and remove the calendar emoji from the metadata row to simplify the header.

### Description
- Updated the mobile card template in `hda-value.html` to introduce a header wrapper `prediction-card__top` and moved the prediction badge into the top-right of the card. 
- Removed the calendar emoji from the metadata span and restructured the fixture row into a balanced three-column layout with the `v` separator preserved. 
- Replaced the previous odds/edge rows with a three-cell stat area `prediction-card__stats` containing `Bookie Price`, `Model Price` and `Value`. 
- Added page-scoped CSS rules in `style.css` under `.hda-value-page` to tune spacing, typography, fixture grid, and centered `stat-cell` layout while keeping the existing dark/orange theme and avoiding cross-page impact.

### Testing
- Verified the intended file changes using `git diff -- hda-value.html style.css` and confirmed the template and CSS updates matched the acceptance criteria. 
- Committed the changes with `git commit -m "Refine hda-value mobile fixture card layout"` which completed successfully. 
- No runtime or unit test suite was modified; the changes are present in `hda-value.html` and `style.css` and are scoped to `.hda-value-page` selectors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb5cbc40c832fb05e1b992f8a7450)