### PR TITLE
Move prediction pill into /hda-value card header and adjust scoped CSS

### DIFF
--- a/hda-value.html
+++ b/hda-value.html
@@ -188,9 +188,9 @@
 
       container.innerHTML = `<div class="prediction-results mobile-prediction-cards">${filtered.map(row => `
         <article class="prediction-card">
-          <div class="prediction-card__top">
+          <div class="prediction-card-header prediction-card__top">
             <div class="prediction-card__meta"><span>${row.day || "-"}</span><span>${row.league || "-"}</span></div>
-            <div class="prediction-card__pick-row"><span class="prediction-card__pick-label">Prediction</span><span class="prediction-badge">${row.prediction || "-"}</span></div>
+            <div class="prediction-pill-wrap"><span class="prediction-badge">${row.prediction || "-"}</span></div>
           </div>
           <div class="prediction-card__fixture"><span class="prediction-card__team prediction-card__team--home">${row.homeTeam || "-"}</span><span class="prediction-card__versus">v</span><span class="prediction-card__team prediction-card__team--away">${row.awayTeam || "-"}</span></div>
           <div class="prediction-card__stats"><div class="stat-cell"><span>Bookie Price</span><strong>${row.bookiePrice || "-"}</strong></div><div class="stat-cell"><span>Model Price</span><strong>${row.modelPrice || "-"}</strong></div><div class="stat-cell"><span>Value</span><strong>${edgeText(row.edgeRaw)}</strong></div></div>

--- a/style.css
+++ b/style.css
@@ -943,10 +943,10 @@ body.home .table-container table {
 }
 
 /* hda-value fixture card refinement */
-.hda-value-page .prediction-card__top { display:flex; align-items:flex-start; justify-content:space-between; gap:10px; margin-bottom:12px; }
-.hda-value-page .prediction-card__meta { margin-bottom:0; }
-.hda-value-page .prediction-card__pick-row { margin-bottom:0; justify-content:flex-end; }
-.hda-value-page .prediction-card__pick-label { display:none; }
+
+.hda-value-page .prediction-card-header { display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+.hda-value-page .prediction-pill-wrap { display:flex; justify-content:flex-end; align-items:center; flex:0 0 auto; }
+.hda-value-page .prediction-card__meta { margin-bottom:0; flex:1 1 auto; min-width:0; }
 .hda-value-page .prediction-badge { max-width:unset; }
 .hda-value-page .prediction-card__fixture { grid-template-columns:minmax(0,1fr) 28px minmax(0,1fr); gap:12px; margin-bottom:14px; }
 .hda-value-page .prediction-card__team { font-size:clamp(.8rem,3.3vw,.96rem); line-height:1.2; }


### PR DESCRIPTION
### Motivation
- Fix the /hda-value prediction card layout so the prediction pill sits in the top-right of the card header alongside the day/league metadata instead of occupying space in the card body.
- Keep changes scoped to the `/hda-value` card layout and shared prediction-card CSS without touching the CSV source, Google Sheet, or other prediction pages.

### Description
- Updated the card template in `hda-value.html` to render a header row (`.prediction-card-header`) containing the day/league metadata and a `prediction-pill-wrap` with the `.prediction-badge`, removing the inline "Prediction" label that previously pushed content down.
- Replaced the previous `.hda-value-page .prediction-card__top` rules with scoped CSS for `.prediction-card-header`, `.prediction-pill-wrap`, and adjusted `.prediction-card__meta` sizing in `style.css` to align metadata left and pill right on a single horizontal row.
- Kept all other card structure and stats layout unchanged to preserve existing visuals and behavior.

### Testing
- Ran `git diff -- hda-value.html style.css` to confirm the markup and CSS delta and it succeeded.
- Ran `git status --short` to verify changes were staged and it succeeded.
- Committed the changes with `git commit` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdb7724534832fa66c32316e2736d4)