### PR TITLE
Move Value into full-width row and tighten fixture alignment on /hda-value

### DIFF
--- a/hda-value.html
+++ b/hda-value.html
@@ -136,6 +136,18 @@
       return t || "Small";
     }
 
+    function valueIconCount(valueLabel) {
+      const key = (valueLabel || "").toLowerCase();
+      if (key === "strong") return 3;
+      if (key === "medium") return 2;
+      return 1;
+    }
+
+    function valueIcons(valueLabel) {
+      const count = valueIconCount(valueLabel);
+      return Array.from({ length: count }, () => '<span class="prediction-value-icon" aria-hidden="true">💰</span>').join("");
+    }
+
     function toCardData(row, mapping) {
       return {
         day: pick(row, mapping, ["day", "match_day", "date", "match_date"]),
@@ -193,7 +205,8 @@
             <div class="prediction-pill-wrap"><span class="prediction-badge">${row.prediction || "-"}</span></div>
           </div>
           <div class="prediction-card__fixture"><span class="prediction-card__team prediction-card__team--home">${row.homeTeam || "-"}</span><span class="prediction-card__versus">v</span><span class="prediction-card__team prediction-card__team--away">${row.awayTeam || "-"}</span></div>
-          <div class="prediction-card__stats"><div class="stat-cell"><span>Bookie Price</span><strong>${row.bookiePrice || "-"}</strong></div><div class="stat-cell"><span>Model Price</span><strong>${row.modelPrice || "-"}</strong></div><div class="stat-cell"><span>Value</span><strong>${edgeText(row.edgeRaw)}</strong></div></div>
+          <div class="prediction-card__stats"><div class="stat-cell"><span>Bookie Price</span><strong>${row.bookiePrice || "-"}</strong></div><div class="stat-cell"><span>Model Price</span><strong>${row.modelPrice || "-"}</strong></div></div>
+          <div class="prediction-value-row"><span class="prediction-value-label">Value</span><span class="prediction-value-icons" aria-label="${edgeText(row.edgeRaw)} value">${valueIcons(edgeText(row.edgeRaw))}</span></div>
         </article>
       `).join("")}</div>`;
     }

--- a/style.css
+++ b/style.css
@@ -948,11 +948,18 @@ body.home .table-container table {
 .hda-value-page .prediction-pill-wrap { display:flex; justify-content:flex-end; align-items:center; flex:0 0 auto; }
 .hda-value-page .prediction-card__meta { margin-bottom:0; flex:1 1 auto; min-width:0; }
 .hda-value-page .prediction-badge { max-width:unset; }
-.hda-value-page .prediction-card__fixture { grid-template-columns:minmax(0,1fr) 28px minmax(0,1fr); gap:12px; margin-bottom:14px; }
+.hda-value-page .prediction-card__fixture { grid-template-columns:minmax(0,1fr) auto minmax(0,1fr); gap:8px; margin:10px 0 12px; justify-items:center; }
 .hda-value-page .prediction-card__team { font-size:clamp(.8rem,3.3vw,.96rem); line-height:1.2; }
-.hda-value-page .prediction-card__versus { font-size:.9rem; letter-spacing:.02em; }
-.hda-value-page .prediction-card__stats { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; }
+.hda-value-page .prediction-card__team--home { justify-self:end; text-align:right; }
+.hda-value-page .prediction-card__team--away { justify-self:start; text-align:left; }
+.hda-value-page .prediction-card__versus { font-size:.9rem; font-weight:900; letter-spacing:.02em; color:#f2980c; }
+.hda-value-page .prediction-card__stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; margin-bottom:10px; }
 .hda-value-page .stat-cell { min-width:0; background:rgba(0,0,0,0.22); border:1px solid rgba(255,255,255,0.07); border-radius:12px; padding:10px 8px; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center; }
 .hda-value-page .stat-cell span { display:block; margin-bottom:5px; color:#bdbdbd; font-size:.7rem; line-height:1.1; }
 .hda-value-page .stat-cell strong { color:#f2f2f2; font-size:.96rem; font-weight:900; font-variant-numeric:tabular-nums; text-transform:uppercase; text-align:center; }
-.hda-value-page .stat-cell:last-child strong { color:#ffae33; }
+
+.hda-value-page .prediction-value-row { display:flex; align-items:center; justify-content:space-between; gap:10px; width:100%; background:rgba(240,147,0,0.10); border:1px solid rgba(240,147,0,0.25); border-radius:12px; padding:10px 12px; }
+.hda-value-page .prediction-value-label { color:#f2f2f2; font-size:.78rem; font-weight:800; letter-spacing:.01em; }
+.hda-value-page .prediction-value-icons { display:inline-flex; align-items:center; gap:6px; }
+.hda-value-page .prediction-value-icon { font-size:.95rem; line-height:1; filter:saturate(1.1); }
+


### PR DESCRIPTION
### Motivation
- Refine the existing `/hda-value` prediction card to match the reference layout by moving the Value display into its own bottom row and improving the fixture composition without rebuilding the card.
- Keep all data bindings, CSV/Google Sheet sources, and other pages intact while improving visual hierarchy and spacing.

### Description
- Updated `hda-value.html` to render two stat boxes (`Bookie Price`, `Model Price`) in the upper stats row and moved `Value` into a dedicated full-width `.prediction-value-row` below them, preserving the existing CSV parsing and data mapping.
- Added lightweight helpers `valueIconCount` and `valueIcons` to convert the computed value strength (`Small/Medium/Strong`) into money-bag icons for the new Value row (display-only change).
- Adjusted `style.css` under the `.hda-value-page` scope to center and tighten the fixture row (`grid-template-columns:minmax(0,1fr) auto minmax(0,1fr)`), right-align the home team and left-align the away team toward the center, and reduce spacing around the orange `v` while keeping the MC Predict theme.
- Changed the stats grid to two columns and added styled rules for `.prediction-value-row` to match the card language (dark surfaces, subtle border, orange accent), with changes scoped to the `/hda-value` page.

### Testing
- Ran `git diff` to confirm the intended edits to `hda-value.html` and `style.css`, which succeeded and showed the applied layout changes.
- Committed the updated files successfully, which confirms repository changes were recorded as expected.
- Attempted an automated Playwright screenshot to validate the visual layout, but it failed because `playwright` is not installed in the environment, so a headless render check could not be produced in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbae62ebc832faab6ebf962e87e97)