### PR TITLE
Fix /hda-value prediction card fixture and value-row layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -948,18 +948,18 @@ body.home .table-container table {
 .hda-value-page .prediction-pill-wrap { display:flex; justify-content:flex-end; align-items:center; flex:0 0 auto; }
 .hda-value-page .prediction-card__meta { margin-bottom:0; flex:1 1 auto; min-width:0; }
 .hda-value-page .prediction-badge { max-width:unset; }
-.hda-value-page .prediction-card__fixture { grid-template-columns:minmax(0,1fr) auto minmax(0,1fr); gap:8px; margin:10px 0 12px; justify-items:center; }
-.hda-value-page .prediction-card__team { font-size:clamp(.8rem,3.3vw,.96rem); line-height:1.2; }
+.hda-value-page .prediction-card__fixture { grid-template-columns:max-content auto max-content; column-gap:8px; margin:10px 0 14px; justify-content:center; align-items:center; }
+.hda-value-page .prediction-card__team { font-size:clamp(.8rem,3.3vw,.96rem); line-height:1.2; min-width:0; }
 .hda-value-page .prediction-card__team--home { justify-self:end; text-align:right; }
 .hda-value-page .prediction-card__team--away { justify-self:start; text-align:left; }
 .hda-value-page .prediction-card__versus { font-size:.9rem; font-weight:900; letter-spacing:.02em; color:#f2980c; }
-.hda-value-page .prediction-card__stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:8px; margin-bottom:10px; }
+.hda-value-page .prediction-card__stats { display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:12px; margin-bottom:12px; }
 .hda-value-page .stat-cell { min-width:0; background:rgba(0,0,0,0.22); border:1px solid rgba(255,255,255,0.07); border-radius:12px; padding:10px 8px; text-align:center; display:flex; flex-direction:column; align-items:center; justify-content:center; }
 .hda-value-page .stat-cell span { display:block; margin-bottom:5px; color:#bdbdbd; font-size:.7rem; line-height:1.1; }
 .hda-value-page .stat-cell strong { color:#f2f2f2; font-size:.96rem; font-weight:900; font-variant-numeric:tabular-nums; text-transform:uppercase; text-align:center; }
 
-.hda-value-page .prediction-value-row { display:flex; align-items:center; justify-content:space-between; gap:10px; width:100%; background:rgba(240,147,0,0.10); border:1px solid rgba(240,147,0,0.25); border-radius:12px; padding:10px 12px; }
-.hda-value-page .prediction-value-label { color:#f2f2f2; font-size:.78rem; font-weight:800; letter-spacing:.01em; }
-.hda-value-page .prediction-value-icons { display:inline-flex; align-items:center; gap:6px; }
+.hda-value-page .prediction-value-row { display:flex; align-items:center; justify-content:space-between; gap:10px; width:100%; min-height:52px; background:linear-gradient(180deg, rgba(242,152,12,0.10), rgba(242,152,12,0.05)); border:1px solid rgba(242,152,12,0.35); border-radius:16px; padding:0 16px; }
+.hda-value-page .prediction-value-label { color:#f1f1f1; font-size:1rem; font-weight:700; letter-spacing:.01em; }
+.hda-value-page .prediction-value-icons { display:flex; align-items:center; gap:8px; margin-left:auto; }
 .hda-value-page .prediction-value-icon { font-size:.95rem; line-height:1; filter:saturate(1.1); }
 


### PR DESCRIPTION
### Motivation
- Restore the /hda-value card layout to match the provided mock so the fixture line is compact/centered and the Value row appears as a dedicated full-width bottom row. 
- Keep all data parsing, CSV/Google Sheet sources, filters, and unrelated pages unchanged. 

### Description
- Updated `.hda-value-page .prediction-card__fixture` to use a 3-part centered grid (`max-content auto max-content`) with `column-gap` and centered alignment so home/away names sit closer to the orange `v`. 
- Added `min-width:0` to `.prediction-card__team` and preserved right/left alignment for `.prediction-card__team--home` and `--away`. 
- Increased spacing for the top stat boxes by adjusting `.prediction-card__stats` gap and bottom margin to better separate them from the Value row. 
- Restored and restyled the Value container (`.prediction-value-row`) to be a distinct full-width row by adding `min-height`, a subtle gradient background, stronger orange border, increased border-radius and horizontal padding, and improved label and icon sizing/spacing (`.prediction-value-label`, `.prediction-value-icons`). 
- All changes are limited to `style.css` under the `.hda-value-page` scope; no HTML/JS/data logic was modified. 

### Testing
- Verified presence and scope of CSS rules with `rg -n "fixture-matchup|prediction-value|hda-value|Bookie Price|Model Price|versus|home-team|away-team" .` and found the relevant selectors. 
- Inspected the modified CSS region with `sed -n '930,975p' style.css` to confirm the updates to fixture and value-row rules. 
- Reviewed the exact edited lines with `nl -ba style.css | sed -n '944,972p'` to validate the final selectors and values; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbd812060832fa5f8f579a13af616)