### PR TITLE
Redesign /historical as modern transparency landing page

### DIFF
--- a/historical.html
+++ b/historical.html
@@ -14,7 +14,7 @@
 
 </head>
 
-<body class="home">
+<body class="home historical-page">
   <div class="home-page">
 
     <!-- Top bar -->
@@ -50,52 +50,51 @@
     </div>
 
     <!-- Main content -->
-    <main class="historical-layout">
-      <section class="historical-card" aria-labelledby="historical-title">
-        <div class="historical-eyebrow">Historical Data</div>
-        <h2 id="historical-title" class="historical-title">Model performance & full history</h2>
-        <p class="historical-intro">
-          This is where you’ll find everything you’re looking for regarding the model’s historical performance.
-        </p>
-
-        <!-- Twitter Link -->
-        <div class="twitter-link">
+    <main class="historical-main">
+      <section class="historical-hero" aria-labelledby="historical-title">
+        <p class="historical-eyebrow">Historical Data</p>
+        <h2 id="historical-title" class="historical-title">Transparency you can verify</h2>
+        <p class="historical-subtitle">Explore the model’s historical performance and review every recorded prediction and outcome.</p>
+        <div class="historical-trust-strip">
+          <span class="trust-dot" aria-hidden="true"></span>
+          <span>Every prediction is logged. Every outcome can be reviewed.</span>
+        </div>
+        <p class="historical-social-link">
           <a href="https://x.com/mc_predict" target="_blank" rel="noopener">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/1/18/X_icon_-_Gray.svg" alt="X Logo">
+            <img src="https://upload.wikimedia.org/wikipedia/commons/1/18/X_icon_-_Gray.svg" alt="X logo">
             @MC_Predict
           </a>
-        </div>
-
-        <!-- Profit / Loss -->
-        <h3 class="historical-section-title">Profit / Loss</h3>
-        <p class="historical-section-copy">
-          Summaries of the overall performance of the model, grouped by value category.
-        </p>
-        <div class="cta-buttons">
-          <a href="/hda-results" class="secondary">PROFIT / LOSS – MATCH RESULT</a>
-          <a href="/uo-results" class="secondary">PROFIT / LOSS – UNDER / OVER 2.5 GOALS</a>
-        </div>
-
-        <!-- History -->
-        <h3 class="historical-section-title">Full History</h3>
-        <p class="historical-section-copy">
-          Breakdowns of <strong>every</strong> fixture the model has provided a prediction for and its outcome.
-        </p>
-        <div class="cta-buttons">
-          <a href="/hda-histf" class="secondary">HISTORY – MATCH RESULT</a>
-          <a href="/uo-histf" class="secondary">HISTORY – UNDER / OVER 2.5 GOALS</a>
-        </div>
-
-        <p class="historical-link-note">
-          All historical data, odds and fixtures are sourced from
-          <a href="https://www.football-data.co.uk/" target="_blank" rel="noopener">Football-Data.co.uk</a>.
         </p>
       </section>
+
+      <section class="historical-feature-grid" aria-label="Historical data features">
+        <article class="historical-card historical-card-history">
+          <h3 class="historical-card-title">Full History</h3>
+          <p class="historical-card-copy">Review every single match the model has processed, the prediction it made, and the final outcome.</p>
+          <p class="historical-card-reason"><strong>Why this matters:</strong> full accountability for every prediction.</p>
+          <div class="historical-card-actions">
+            <a class="historical-action-btn" href="/hda-histf">MATCH RESULT HISTORY <span aria-hidden="true">›</span></a>
+            <a class="historical-action-btn" href="/uo-histf">UNDER / OVER 2.5 HISTORY <span aria-hidden="true">›</span></a>
+          </div>
+        </article>
+
+        <article class="historical-card historical-card-profit">
+          <h3 class="historical-card-title">Profit / Loss</h3>
+          <p class="historical-card-copy">Break down performance by value category and track how selections have performed over time.</p>
+          <p class="historical-card-reason"><strong>Why this matters:</strong> transparent performance by value tier.</p>
+          <div class="historical-card-actions">
+            <a class="historical-action-btn" href="/hda-results">MATCH RESULT PROFIT / LOSS <span aria-hidden="true">›</span></a>
+            <a class="historical-action-btn" href="/uo-results">UNDER / OVER 2.5 PROFIT / LOSS <span aria-hidden="true">›</span></a>
+          </div>
+        </article>
+      </section>
+
+      <footer class="historical-source-credit">
+        <p>Historical data, odds and fixtures sourced from <a href="https://www.football-data.co.uk/" target="_blank" rel="noopener">Football-Data.co.uk</a>.</p>
+        <p>MC Predict is for informational purposes only and does not guarantee outcomes. Please bet responsibly.</p>
+      </footer>
     </main>
 
-    <footer class="home-footer">
-      MC Predict is for informational purposes only and does not guarantee outcomes. Please bet responsibly.
-    </footer>
   </div>
 
   <!-- Bottom mobile nav -->

--- a/style.css
+++ b/style.css
@@ -963,3 +963,223 @@ body.home .table-container table {
 .hda-value-page .prediction-value-icons { display:flex; align-items:center; gap:8px; margin-left:auto; }
 .hda-value-page .prediction-value-icon { font-size:.95rem; line-height:1; filter:saturate(1.1); }
 
+
+/* ---------------------------
+   Historical landing page
+--------------------------- */
+body.historical-page {
+  background: radial-gradient(circle at top left, #23262b, #111214 48%);
+  color: #f3f4f6;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  padding: 0;
+}
+
+.historical-page .home-page {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 12px 14px 40px;
+}
+
+.historical-page .historical-main {
+  padding-bottom: 10px;
+}
+
+.historical-page .historical-hero {
+  margin: 20px 0 26px;
+  max-width: 760px;
+}
+
+.historical-eyebrow {
+  margin: 0 0 16px;
+  color: #f7931a;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+}
+
+.historical-title {
+  margin: 0;
+  color: #f3f4f6;
+  font-size: clamp(1.95rem, 4.6vw, 3.15rem);
+  line-height: 1.08;
+}
+
+.historical-subtitle {
+  margin: 14px 0 0;
+  color: #a2aab5;
+  font-size: clamp(1.08rem, 2vw, 2rem);
+  line-height: 1.35;
+  max-width: 700px;
+}
+
+.historical-trust-strip {
+  margin-top: 22px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(30, 33, 39, 0.7);
+  color: #b8c0ca;
+  padding: 14px 16px;
+}
+
+.trust-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #f7931a;
+  box-shadow: 0 0 8px rgba(247, 147, 26, 0.5);
+  flex: 0 0 auto;
+}
+
+.historical-social-link {
+  margin: 16px 0 0;
+}
+
+.historical-social-link a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #6f7782;
+  font-size: 1rem;
+  text-decoration: none;
+}
+
+.historical-social-link img {
+  width: 20px;
+  height: 20px;
+  opacity: 0.5;
+}
+
+.historical-feature-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.historical-page .historical-card {
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: linear-gradient(142deg, rgba(247, 147, 26, 0.12), rgba(27, 30, 37, 0.96) 38%, rgba(24, 27, 34, 0.97));
+  padding: 40px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+}
+
+.historical-card-title {
+  margin: 0;
+  font-size: clamp(2rem, 2.8vw, 2.8rem);
+  color: #f3f4f6;
+}
+
+.historical-card-copy,
+.historical-card-reason {
+  color: #a8b1bd;
+  font-size: 1.03rem;
+  line-height: 1.4;
+}
+
+.historical-card-copy { margin: 16px 0 0; }
+.historical-card-reason { margin: 20px 0 0; }
+.historical-card-reason strong { color: #f7931a; }
+
+.historical-card-actions {
+  margin-top: 26px;
+  display: grid;
+  gap: 12px;
+}
+
+.historical-action-btn {
+  border: 1px solid rgba(247, 147, 26, 0.75);
+  background: linear-gradient(100deg, rgba(247, 147, 26, 0.14), rgba(40, 40, 40, 0.55));
+  color: #f5f7fb;
+  border-radius: 13px;
+  min-height: 52px;
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-decoration: none;
+}
+
+.historical-action-btn:hover {
+  text-decoration: none;
+  border-color: #ffaf47;
+  box-shadow: 0 0 0 2px rgba(247, 147, 26, 0.14), 0 0 16px rgba(247, 147, 26, 0.2);
+  background: linear-gradient(100deg, rgba(247, 147, 26, 0.23), rgba(58, 58, 58, 0.6));
+}
+
+.historical-action-btn span {
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.historical-source-credit {
+  margin-top: 26px;
+  padding-top: 22px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.historical-source-credit p {
+  margin: 0;
+  color: #9ba3af;
+  font-size: 1.03rem;
+}
+
+.historical-source-credit p + p {
+  margin-top: 12px;
+  font-size: 0.95rem;
+  color: #707985;
+}
+
+.historical-source-credit a {
+  color: #f7931a;
+}
+
+@media (max-width: 960px) {
+  .historical-feature-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 767px) {
+  .historical-page .home-page {
+    padding: 12px 12px calc(112px + env(safe-area-inset-bottom));
+  }
+
+  .historical-page .historical-hero {
+    margin-top: 10px;
+    margin-bottom: 18px;
+  }
+
+  .historical-subtitle {
+    font-size: 1.05rem;
+  }
+
+  .historical-trust-strip {
+    width: 100%;
+    padding: 12px 14px;
+  }
+
+  .historical-page .historical-card {
+    padding: 24px;
+    border-radius: 18px;
+  }
+
+  .historical-card-title {
+    font-size: 2rem;
+  }
+
+  .historical-card-copy,
+  .historical-card-reason {
+    font-size: 1.02rem;
+  }
+
+  .historical-action-btn {
+    width: 100%;
+    font-size: 0.95rem;
+    min-height: 50px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Modernise the existing `/historical` landing into a credibility and transparency hub that matches the homepage visual direction and highlights two core features: Full History and Profit / Loss.
- Preserve the global header, burger menu, mobile bottom nav and existing CTA destinations while improving content hierarchy, readability and responsive behavior.

### Description
- Reworked `historical.html` structure to introduce a hero (`.historical-hero`) with eyebrow, headline, supporting copy, a trust strip and a subdued `@MC_Predict` social link, and replaced the old list with a two-card feature grid (`.historical-feature-grid`).
- Added two equal feature cards (`.historical-card-history` and `.historical-card-profit`) each containing two CTAs that keep the original targets: `/hda-histf`, `/uo-histf`, `/hda-results`, and `/uo-results`.
- Added page-scoped styles to `style.css` under a dedicated Historical section using the `.historical-page` namespace to provide dark premium visuals, orange accents, rounded elevated cards, full-width CTA styling and responsive grid behavior (two-column desktop / stacked mobile).
- Kept all global header/nav behaviour and site script references intact and avoided changes to global navigation CSS.

### Testing
- Ran repository checks and diffs: reviewed `git diff` and committed the changes with `git commit` successfully (commit message: "Redesign historical page into transparency landing layout").
- Verified presence and targets of CTAs and new classes with `rg -n "hda-histf|uo-histf|hda-results|uo-results|historical-social-link|historical-feature-grid" historical.html style.css` which returned the expected occurrences.
- Attempted visual automation with `npx playwright --version` but it failed due to npm registry restrictions (403), so automated visual/viewport checks could not be run in this environment.
- No other automated tests were added; responsive breakpoints and layout behavior were implemented in CSS for the requested widths but visual verification remains recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddc6eef14832fbaa76c229c7cdf2c)