### PR TITLE
Refine /historical landing page structure and page-scoped styles

### DIFF
--- a/historical.html
+++ b/historical.html
@@ -56,12 +56,11 @@
         <h2 id="historical-title" class="historical-title">Transparency you can verify</h2>
         <p class="historical-subtitle">Explore the model’s historical performance and review every recorded prediction and outcome.</p>
         <div class="historical-trust-strip">
-          <span class="trust-dot" aria-hidden="true"></span>
+          <span class="historical-trust-dot" aria-hidden="true"></span>
           <span>Every prediction is logged. Every outcome can be reviewed.</span>
         </div>
         <p class="historical-social-link">
           <a href="https://x.com/mc_predict" target="_blank" rel="noopener">
-            <img src="https://upload.wikimedia.org/wikipedia/commons/1/18/X_icon_-_Gray.svg" alt="X logo">
             @MC_Predict
           </a>
         </p>
@@ -73,8 +72,8 @@
           <p class="historical-card-copy">Review every single match the model has processed, the prediction it made, and the final outcome.</p>
           <p class="historical-card-reason"><strong>Why this matters:</strong> full accountability for every prediction.</p>
           <div class="historical-card-actions">
-            <a class="historical-action-btn" href="/hda-histf">MATCH RESULT HISTORY <span aria-hidden="true">›</span></a>
-            <a class="historical-action-btn" href="/uo-histf">UNDER / OVER 2.5 HISTORY <span aria-hidden="true">›</span></a>
+            <a class="historical-action-btn" href="/hda-histf">MATCH RESULT HISTORY <span aria-hidden="true">→</span></a>
+            <a class="historical-action-btn" href="/uo-histf">UNDER / OVER 2.5 HISTORY <span aria-hidden="true">→</span></a>
           </div>
         </article>
 
@@ -83,8 +82,8 @@
           <p class="historical-card-copy">Break down performance by value category and track how selections have performed over time.</p>
           <p class="historical-card-reason"><strong>Why this matters:</strong> transparent performance by value tier.</p>
           <div class="historical-card-actions">
-            <a class="historical-action-btn" href="/hda-results">MATCH RESULT PROFIT / LOSS <span aria-hidden="true">›</span></a>
-            <a class="historical-action-btn" href="/uo-results">UNDER / OVER 2.5 PROFIT / LOSS <span aria-hidden="true">›</span></a>
+            <a class="historical-action-btn" href="/hda-results">MATCH RESULT PROFIT / LOSS <span aria-hidden="true">→</span></a>
+            <a class="historical-action-btn" href="/uo-results">UNDER / OVER 2.5 PROFIT / LOSS <span aria-hidden="true">→</span></a>
           </div>
         </article>
       </section>

--- a/style.css
+++ b/style.css
@@ -1025,7 +1025,7 @@ body.historical-page {
   padding: 14px 16px;
 }
 
-.trust-dot {
+.historical-trust-dot {
   width: 12px;
   height: 12px;
   border-radius: 999px;
@@ -1041,16 +1041,10 @@ body.historical-page {
 .historical-social-link a {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
   color: #6f7782;
-  font-size: 1rem;
+  font-size: 0.92rem;
   text-decoration: none;
-}
-
-.historical-social-link img {
-  width: 20px;
-  height: 20px;
-  opacity: 0.5;
+  letter-spacing: 0.02em;
 }
 
 .historical-feature-grid {


### PR DESCRIPTION
### Motivation
- Align the live `/historical` page with the modern two-card landing design and ensure the Full History card appears before Profit / Loss while preserving existing CTA destinations.
- Improve page-specific class naming and reduce visual prominence of the social handle and trust strip assets to match the current site tone.

### Description
- Updated `historical.html` to use a page-specific trust indicator class (`historical-trust-dot`), removed the X logo image so `@MC_Predict` remains present but visually subtle, and kept the hero headline `Transparency you can verify`.
- Ensured the feature order is preserved with the Full History card first and the Profit / Loss card second and preserved existing CTA links (`/hda-histf`, `/uo-histf`, `/hda-results`, `/uo-results`).
- Replaced the chevron character in CTAs with a right arrow glyph for consistency and accessibility, and tightened markup around the hero/trust/social area.
- Updated `style.css` with `.historical-trust-dot`, refined `.historical-social-link a` typography and spacing, removed the unused social image rules, and retained the two-column desktop / single-column mobile responsive grid and page-scoped visual language.

### Testing
- Located and inspected affected files with repository search to confirm targets (`historical.html`, `style.css`) were updated as intended.
- Reviewed file diffs and specific file content with `git diff` and paginated listings (`nl`/`sed`) to verify the new class name, removed logo, arrow glyphs, and preserved CTA `href` values; these checks succeeded.
- Verified repository status with `git status` to confirm the working tree reflected only the intended changes and there were no unrelated modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fddeb74f18832faca60667d36a8098)