### PR TITLE
Branded fullscreen loading overlay for prediction pages (hda-value)

### DIFF
--- a/hda-value.html
+++ b/hda-value.html
@@ -9,12 +9,22 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
 </head>
 <body class="home prediction-page">
-  <div class="loading-overlay" id="loadingOverlay" aria-live="polite">
-    <div class="loading-ball">⚽</div>
-    <div class="loading-pitch-line"></div>
-    <div class="loading-title">Loading predictions</div>
-    <p class="loading-subtitle">Fetching the latest model output and market prices.</p>
-    <div class="loading-ticker">Fetching latest sheet data...</div>
+  <div class="loading-overlay" id="loadingOverlay" aria-live="polite" role="status">
+    <div class="loading-card">
+      <div class="loading-brand">
+        <img src="/images/mcpredcirclebg.png" alt="MC Predict" class="loading-logo">
+        <span>MCPREDICT</span>
+      </div>
+
+      <div class="loading-ball" aria-hidden="true">⚽</div>
+      <div class="loading-pitch-line" aria-hidden="true"></div>
+
+      <div class="loading-title">Loading predictions</div>
+      <p class="loading-subtitle">Fetching the latest model output and market prices.</p>
+
+      <div class="loading-progress" aria-hidden="true"><span></span></div>
+      <div class="loading-ticker">Fetching latest sheet data...</div>
+    </div>
   </div>
 
   <div class="prediction-shell">
@@ -93,7 +103,7 @@
     const activeResultFilters = new Set();
 
     const predictionUtils = window.MCPredictPrediction;
-    function hideLoadingOverlay() { const overlay = document.getElementById("loadingOverlay"); if (!overlay) return; overlay.classList.add("hidden"); setTimeout(() => { overlay.style.display = "none"; }, 450); }
+    function hideLoadingOverlay() { predictionUtils.hideLoadingOverlay("loadingOverlay"); }
     function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
 
     function createFilterButton(text, onClick) {

--- a/site.js
+++ b/site.js
@@ -50,6 +50,14 @@
     return `<article class='prediction-card'><div class='prediction-card__meta'><span class='prediction-card__day'>${rowData.day}</span><span class='prediction-card__league'>${rowData.league}</span></div><div class='prediction-card__pick-row'><span class='prediction-card__pick-label'>Prediction</span><span class='prediction-badge'>${rowData.prediction}</span></div><div class='prediction-card__fixture'><span class='prediction-card__team prediction-card__team--home'>${rowData.homeTeam}</span><span class='prediction-card__versus'>v</span><span class='prediction-card__team prediction-card__team--away'>${rowData.awayTeam}</span></div><div class='prediction-card__odds'><div class='odds-cell'><span>Bookmaker Price</span><strong>${rowData.bookmakerPrice}</strong></div><div class='odds-cell'><span>Model Price</span><strong>${rowData.modelPrice}</strong></div></div><div class='prediction-card__edge'><span>Value / Edge Strength</span><strong class='${edge.cls}'>${edge.label}</strong></div></article>`;
   }
 
+
+  function hideLoadingOverlay(overlayId='loadingOverlay'){
+    const overlay=document.getElementById(overlayId);
+    if(!overlay) return;
+    overlay.classList.add('is-hidden');
+    window.setTimeout(()=>{ overlay.style.display='none'; }, 320);
+  }
+
   function initMenu(){/* unchanged */
     const overlay=document.getElementById('menuOverlay');
     const open=document.getElementById('openMenu');
@@ -90,6 +98,6 @@
     document.addEventListener('keydown',(event)=>{if(event.key==='Escape' && !panel.hidden) closeBottomMenu();});
   }
 
-  window.MCPredictPrediction = { csvToRows, extractRowData, renderPredictionCard, sanitize };
+  window.MCPredictPrediction = { csvToRows, extractRowData, renderPredictionCard, sanitize, hideLoadingOverlay };
   document.addEventListener('DOMContentLoaded',()=>{initMenu();initBottomNav();});
 })();

--- a/style.css
+++ b/style.css
@@ -1211,8 +1211,66 @@ nav a[aria-current="page"]:focus-visible,
 .section-nav a[aria-current="page"]:focus-visible { color:#111 !important; }
 
 /* Shared prediction loading overlay */
-.loading-overlay { position: fixed; inset: 0; z-index: 9999; display: flex; align-items: center; justify-content: center; flex-direction: column; padding: 24px; background: radial-gradient(circle at top, rgba(60,60,62,0.98), rgba(24,24,26,0.98)); text-align:center; }
-.loading-overlay.hidden, .loading-overlay.is-hidden { display:none !important; }
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background:
+    radial-gradient(circle at top, rgba(242, 152, 12, 0.16), transparent 36%),
+    linear-gradient(180deg, rgba(26, 27, 31, 0.985) 0%, rgba(18, 19, 22, 0.985) 100%);
+  text-align: center;
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 260ms ease, visibility 260ms ease;
+}
+
+.loading-overlay.hidden,
+.loading-overlay.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.loading-card {
+  width: min(100%, 420px);
+  background: rgba(28, 30, 36, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 22px;
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.45), 0 0 36px rgba(242, 152, 12, 0.14);
+  padding: 28px 24px;
+}
+
+.loading-brand { display:inline-flex; align-items:center; gap:10px; font-size:.75rem; font-weight:700; letter-spacing:.16em; color:#f5b45c; margin-bottom:16px; }
+.loading-logo { width:28px; height:28px; border-radius:50%; object-fit:cover; }
+.loading-ball { font-size:2.35rem; line-height:1; margin-bottom:8px; animation: loadingBallBounce 1.35s ease-in-out infinite; transform-origin:center bottom; }
+.loading-pitch-line { width:76px; height:4px; border-radius:999px; margin:0 auto 14px; background:linear-gradient(90deg, rgba(242,152,12,0.2), rgba(242,152,12,0.9), rgba(242,152,12,0.2)); animation: loadingPulse 1.35s ease-in-out infinite; }
+.loading-title { margin:0; color:#fff; font-size:1.16rem; font-weight:700; }
+.loading-subtitle { margin:8px 0 16px; color:#b9bdc9; font-size:.92rem; line-height:1.45; }
+.loading-progress { width:100%; height:6px; border-radius:999px; background:rgba(255,255,255,0.1); overflow:hidden; margin:0 auto 12px; }
+.loading-progress span { display:block; height:100%; width:38%; border-radius:inherit; background:linear-gradient(90deg, #f2990c, #f5bb62); animation: loadingBar 1.25s ease-in-out infinite; }
+.loading-ticker { margin:0; color:#f0b563; font-size:.83rem; letter-spacing:.01em; }
+
+@keyframes loadingBallBounce {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-7px) scale(1.05); }
+}
+@keyframes loadingPulse {
+  0%, 100% { opacity: .62; transform: scaleX(.92); }
+  50% { opacity: 1; transform: scaleX(1.06); }
+}
+@keyframes loadingBar {
+  0% { transform: translateX(-120%); }
+  100% { transform: translateX(280%); }
+}
+
+@media (max-width: 480px) {
+  .loading-overlay { padding: 16px; }
+  .loading-card { width: min(100%, 360px); padding: 24px 18px; border-radius: 18px; }
+}
 
 /* WC26 shared shell + sub-navigation */
 .wc26-page, .wrap { max-width: 960px; margin: 0 auto; padding: 0 14px 56px; }


### PR DESCRIPTION
### Motivation
- Improve the unfinished, top-left plain-text loading state by replacing it with a polished, branded fullscreen overlay that prevents underlying content from visually competing while sheet data loads.
- Provide a reusable pattern (CSS + JS) so other prediction pages can adopt the same loading UX without redesigning page content.

### Description
- Replaced the inline loader in `hda-value.html` with a centered `loading-card` wrapper that includes MC Predict branding, title, subtitle, ticker text, a larger football element and an indeterminate orange progress bar (`.loading-card` markup).
- Upgraded shared loader styles in `style.css` to a fullscreen `position: fixed` overlay with high `z-index`, dark radial/linear background, rounded card, subtle border, shadow/glow, orange accents, bounce/pulse animations, and responsive sizing for mobile and desktop.
- Added a shared `hideLoadingOverlay()` helper in `site.js` (exposed as `MCPredictPrediction.hideLoadingOverlay`) which applies a fade-out class (`.is-hidden`) and then sets `display: none` after the transition to fully remove the overlay from interaction/layout.
- Wired `hda-value.html` to call the shared hide helper so the overlay is removed in success/finally/error paths without leaving loading text visible.

### Testing
- Ran a repository search for loader strings with `rg -n "loadingOverlay|loading-overlay|Loading predictions|Fetching latest sheet data" .` to confirm occurrences were updated and the new markup is present; command completed successfully.
- Inspected the modified files via `sed -n` outputs to verify the new `loading-card` markup in `hda-value.html`, the `hideLoadingOverlay` helper in `site.js`, and the CSS changes in `style.css`; inspection showed the intended changes.
- Verified the overlay uses `position: fixed; inset: 0; z-index: 99999`, responsive card sizing, animations, and that `MCPredictPrediction.hideLoadingOverlay()` is referenced from the page script; checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f3d2fcd4832fad3f7b92ef318bfe)