### PR TITLE
Add lightweight in-content loading message for prediction pages

### DIFF
--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -64,6 +64,13 @@
       <p class="prediction-note">Bookmaker and model prices are shown side-by-side with the value for each selection.</p>
 
       <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="predictionLoading" class="prediction-loading is-hidden" role="status" aria-live="polite">
+        <span class="prediction-loading-dot" aria-hidden="true"></span>
+        <div>
+          <strong>Loading latest predictions…</strong>
+          <span>Fetching model prices and fixture data.</span>
+        </div>
+      </div>
       <div id="sheet-data"></div>
     </section>
   </div>
@@ -85,7 +92,16 @@
     const activeResultFilters = new Set();
 
     const predictionUtils = window.MCPredictPrediction;
-    function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
+    function setPredictionLoading(isLoading) {
+      const loading = document.getElementById("predictionLoading");
+      if (!loading) return;
+      loading.classList.toggle("is-hidden", !isLoading);
+    }
+
+    function showLoadError() {
+      setPredictionLoading(false);
+      document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>";
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -147,6 +163,7 @@
     }
 
     async function loadCSV() {
+      setPredictionLoading(true);
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
@@ -158,6 +175,8 @@
       } catch (error) {
         console.error(error);
         showLoadError();
+      } finally {
+        setPredictionLoading(false);
       }
     }
 

--- a/hda-value.html
+++ b/hda-value.html
@@ -65,6 +65,13 @@
       <p class="prediction-note">Bookmaker and model prices are shown side-by-side with the value for each selection.</p>
 
       <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="predictionLoading" class="prediction-loading is-hidden" role="status" aria-live="polite">
+        <span class="prediction-loading-dot" aria-hidden="true"></span>
+        <div>
+          <strong>Loading latest predictions…</strong>
+          <span>Fetching model prices and fixture data.</span>
+        </div>
+      </div>
       <div id="sheet-data"></div>
     </section>
   </div>
@@ -86,7 +93,16 @@
     const activeResultFilters = new Set();
 
     const predictionUtils = window.MCPredictPrediction;
-    function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
+    function setPredictionLoading(isLoading) {
+      const loading = document.getElementById("predictionLoading");
+      if (!loading) return;
+      loading.classList.toggle("is-hidden", !isLoading);
+    }
+
+    function showLoadError() {
+      setPredictionLoading(false);
+      document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>";
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -148,6 +164,7 @@
     }
 
     async function loadCSV() {
+      setPredictionLoading(true);
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
@@ -159,6 +176,8 @@
       } catch (error) {
         console.error(error);
         showLoadError();
+      } finally {
+        setPredictionLoading(false);
       }
     }
 

--- a/style.css
+++ b/style.css
@@ -884,6 +884,48 @@ body.home .table-container table {
 .prediction-filter-button { border:1px solid rgba(255,255,255,.1); background:#2f333d; color:#e7e7ea; padding:9px 15px; border-radius:999px; font-weight:700; cursor:pointer; }
 .prediction-filter-button--active { background:linear-gradient(135deg,#f7931a,#f4b244); color:#1f1f1f; border-color:transparent; }
 .prediction-results-summary { margin: 0; }
+.prediction-loading {
+  display:flex;
+  align-items:center;
+  gap:12px;
+  width:min(100%,680px);
+  margin:18px auto;
+  padding:14px 16px;
+  border-radius:16px;
+  background:rgba(25,27,33,.92);
+  border:1px solid rgba(255,255,255,.08);
+  box-shadow:0 12px 28px rgba(0,0,0,.22);
+  color:#f5f5f5;
+}
+.prediction-loading.is-hidden { display:none; }
+.prediction-loading-dot {
+  width:11px;
+  height:11px;
+  flex:0 0 11px;
+  border-radius:999px;
+  background:#f2980c;
+  box-shadow:0 0 0 rgba(242,152,12,.45);
+  animation:predictionLoadingPulse 1.25s ease-in-out infinite;
+}
+.prediction-loading strong {
+  display:block;
+  font-size:.95rem;
+  line-height:1.25;
+  font-weight:700;
+  letter-spacing:.01em;
+}
+.prediction-loading span:not(.prediction-loading-dot) {
+  display:block;
+  margin-top:3px;
+  font-size:.82rem;
+  line-height:1.3;
+  color:#bdbdbd;
+}
+@keyframes predictionLoadingPulse {
+  0% { transform:scale(.9); box-shadow:0 0 0 0 rgba(242,152,12,.45); }
+  70% { transform:scale(1); box-shadow:0 0 0 8px rgba(242,152,12,0); }
+  100% { transform:scale(.9); box-shadow:0 0 0 0 rgba(242,152,12,0); }
+}
 .selection-summary { margin: 14px 20px 8px; padding: 12px 14px; background: rgba(255,255,255,0.045); border: 1px solid rgba(255,255,255,0.08); border-radius: 16px; }
 .selection-summary strong,
 .selection-summary span { display:block; }
@@ -925,8 +967,19 @@ body.home .table-container table {
   .prediction-panel { padding: 28px; }
   .prediction-title { font-size: 3rem; }
   .prediction-filter-label { font-size:1.1rem; }
+  .prediction-loading { margin:14px 20px; }
   .mobile-prediction-cards { display:none; }
   .desktop-prediction-table { display:block; }
+}
+
+@media (max-width:600px) {
+  .prediction-loading {
+    margin:14px 0;
+    padding:13px 14px;
+    border-radius:14px;
+  }
+  .prediction-loading strong { font-size:.9rem; }
+  .prediction-loading span:not(.prediction-loading-dot) { font-size:.78rem; }
 }
 
 /* hda-value page scoped layout updates */

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -64,6 +64,13 @@
       <p class="prediction-note">Bookmaker and model prices are shown side-by-side with the value for each selection.</p>
 
       <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="predictionLoading" class="prediction-loading is-hidden" role="status" aria-live="polite">
+        <span class="prediction-loading-dot" aria-hidden="true"></span>
+        <div>
+          <strong>Loading latest predictions…</strong>
+          <span>Fetching model prices and fixture data.</span>
+        </div>
+      </div>
       <div id="sheet-data"></div>
     </section>
   </div>
@@ -85,7 +92,16 @@
     const activeResultFilters = new Set();
 
     const predictionUtils = window.MCPredictPrediction;
-    function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
+    function setPredictionLoading(isLoading) {
+      const loading = document.getElementById("predictionLoading");
+      if (!loading) return;
+      loading.classList.toggle("is-hidden", !isLoading);
+    }
+
+    function showLoadError() {
+      setPredictionLoading(false);
+      document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>";
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -147,6 +163,7 @@
     }
 
     async function loadCSV() {
+      setPredictionLoading(true);
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
@@ -158,6 +175,8 @@
       } catch (error) {
         console.error(error);
         showLoadError();
+      } finally {
+        setPredictionLoading(false);
       }
     }
 

--- a/uo-value.html
+++ b/uo-value.html
@@ -64,6 +64,13 @@
       <p class="prediction-note">Bookmaker and model prices are shown side-by-side with the value for each selection.</p>
 
       <div id="results-summary" class="prediction-results-summary" aria-live="polite"></div>
+      <div id="predictionLoading" class="prediction-loading is-hidden" role="status" aria-live="polite">
+        <span class="prediction-loading-dot" aria-hidden="true"></span>
+        <div>
+          <strong>Loading latest predictions…</strong>
+          <span>Fetching model prices and fixture data.</span>
+        </div>
+      </div>
       <div id="sheet-data"></div>
     </section>
   </div>
@@ -85,7 +92,16 @@
     const activeResultFilters = new Set();
 
     const predictionUtils = window.MCPredictPrediction;
-    function showLoadError() { document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>"; }
+    function setPredictionLoading(isLoading) {
+      const loading = document.getElementById("predictionLoading");
+      if (!loading) return;
+      loading.classList.toggle("is-hidden", !isLoading);
+    }
+
+    function showLoadError() {
+      setPredictionLoading(false);
+      document.getElementById("sheet-data").innerHTML = "<p class='prediction-empty'>We couldn’t load live data. Please refresh in a minute.</p>";
+    }
 
     function createFilterButton(text, onClick) {
       const btn = document.createElement("button");
@@ -147,6 +163,7 @@
     }
 
     async function loadCSV() {
+      setPredictionLoading(true);
       try {
         const response = await fetch(csvUrl);
         if (!response.ok) throw new Error("Network error");
@@ -158,6 +175,8 @@
       } catch (error) {
         console.error(error);
         showLoadError();
+      } finally {
+        setPredictionLoading(false);
       }
     }
 


### PR DESCRIPTION
### Motivation
- Provide a small, non-blocking loading status inside the prediction content area so users see progress while Google Sheet data is fetched without reintroducing a full-screen overlay.
- Keep the UI consistent with the MC Predict dark/orange theme and ensure the loading state disappears reliably on success or error.

### Description
- Inserted an inline status block `#predictionLoading` (HTML snippet) directly above `#sheet-data` in `hda-value.html`, `hda-highchance.html`, `uo-value.html`, and `uo-highchance.html` so the message sits within the normal page layout.
- Added a `setPredictionLoading(isLoading)` helper and wired calls into the pages' fetch lifecycle so the loading message is shown before `fetch` and hidden in both success (`finally`) and error (`showLoadError`) paths.
- Added shared styles to `style.css` for `.prediction-loading`, `.prediction-loading-dot`, and the `predictionLoadingPulse` animation, including responsive adjustments to keep the component compact and aligned with existing styling.
- Ensured the change does not reintroduce any fullscreen overlay or body-level loading UI and preserved existing empty/error rendering behavior.

### Testing
- Used `rg` searches to confirm the new `predictionLoading` markup and `setPredictionLoading` helper appear in `hda-value.html`, `hda-highchance.html`, `uo-value.html`, `uo-highchance.html`, and `style.css` and that the animation rules are present.
- Used `rg` to verify there is no active usage of `loadingOverlay` / `loading-overlay` in the affected pages or stylesheet.
- Verified the modified files are present and updated: `hda-value.html`, `hda-highchance.html`, `uo-value.html`, `uo-highchance.html`, and `style.css`.
- All automated checks and repository searches listed above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fcda6984832fa0be744be80649ac)