### PR TITLE
Fix broken summary calculations on historical HDA/UO pages

### DIFF
--- a/hda-histd.html
+++ b/hda-histd.html
@@ -979,7 +979,7 @@
           // --- Summary update ---
           function updateSummary() {
             const api = table;
-            const rows = api.rows({ filter: 'applied' }).data();
+            const rows = api.rows({ search: 'applied' }).data();
             const totalBets = rows.length;
 
             let correctBets = 0;
@@ -988,14 +988,15 @@
             for (let i = 0; i < rows.length; i++) {
               const row = rows[i];
 
-              // Correct? column (HTML with FA icon)
-              const correctHtml = row[11] || "";
-              if (typeof correctHtml === "string" && correctHtml.indexOf("fa-circle-check") !== -1) {
+              // Correct? column (last column, HTML icon or text fallback)
+              const correctCol = row[9] || "";
+              const correctHtml = String(correctCol).toLowerCase();
+              if (correctHtml.includes('fa-circle-check') || correctHtml.includes('correct') || correctHtml.includes('✅') || correctHtml.includes('✔') || correctHtml.includes('✓')) {
                 correctBets++;
               }
 
               // P/L column
-              const plCol = row[10];
+              const plCol = row[8];
               let plVal = 0;
               if (plCol && typeof plCol.sort !== "undefined") {
                 plVal = plCol.sort;
@@ -1005,8 +1006,8 @@
               totalPL += plVal;
             }
 
-            $('#summary-bets').text(totalBets);
-            $('#summary-correct').text(correctBets);
+            $('#summary-bets').text(totalBets.toLocaleString('en-GB'));
+            $('#summary-correct').text(correctBets.toLocaleString('en-GB'));
 
             // Update PL display + colour
             const plDisplay = formatPL(totalPL);

--- a/hda-histf.html
+++ b/hda-histf.html
@@ -982,7 +982,7 @@
           // --- Summary update ---
           function updateSummary() {
             const api = table;
-            const rows = api.rows({ filter: 'applied' }).data();
+            const rows = api.rows({ search: 'applied' }).data();
             const totalBets = rows.length;
 
             let correctBets = 0;
@@ -991,14 +991,15 @@
             for (let i = 0; i < rows.length; i++) {
               const row = rows[i];
 
-              // Correct? column (HTML with FA icon)
-              const correctHtml = row[11] || "";
-              if (typeof correctHtml === "string" && correctHtml.indexOf("fa-circle-check") !== -1) {
+              // Correct? column (last column, HTML icon or text fallback)
+              const correctCol = row[9] || "";
+              const correctHtml = String(correctCol).toLowerCase();
+              if (correctHtml.includes('fa-circle-check') || correctHtml.includes('correct') || correctHtml.includes('✅') || correctHtml.includes('✔') || correctHtml.includes('✓')) {
                 correctBets++;
               }
 
               // P/L column
-              const plCol = row[10];
+              const plCol = row[8];
               let plVal = 0;
               if (plCol && typeof plCol.sort !== "undefined") {
                 plVal = plCol.sort;
@@ -1008,8 +1009,8 @@
               totalPL += plVal;
             }
 
-            $('#summary-bets').text(totalBets);
-            $('#summary-correct').text(correctBets);
+            $('#summary-bets').text(totalBets.toLocaleString('en-GB'));
+            $('#summary-correct').text(correctBets.toLocaleString('en-GB'));
 
             // Update PL display + colour
             const plDisplay = formatPL(totalPL);

--- a/uo-histd.html
+++ b/uo-histd.html
@@ -977,7 +977,7 @@
 
           // --- Summary update ---
           function updateSummary() {
-            const rows = table.rows({ filter: 'applied' }).data();
+            const rows = table.rows({ search: 'applied' }).data();
             const totalBets = rows.length;
 
             let correctBets = 0;
@@ -986,14 +986,15 @@
             for (let i = 0; i < rows.length; i++) {
               const row = rows[i];
 
-              // Correct? column (HTML with FA icon)
-              const correctHtml = row[11] || "";
-              if (typeof correctHtml === "string" && correctHtml.indexOf("fa-circle-check") !== -1) {
+              // Correct? column (last column, HTML icon or text fallback)
+              const correctCol = row[9] || "";
+              const correctHtml = String(correctCol).toLowerCase();
+              if (correctHtml.includes('fa-circle-check') || correctHtml.includes('correct') || correctHtml.includes('✅') || correctHtml.includes('✔') || correctHtml.includes('✓')) {
                 correctBets++;
               }
 
               // P/L column
-              const plCol = row[10];
+              const plCol = row[8];
               let plVal = 0;
               if (plCol && typeof plCol.sort !== "undefined") {
                 plVal = plCol.sort;
@@ -1003,8 +1004,8 @@
               totalPL += plVal;
             }
 
-            $('#summary-bets').text(totalBets);
-            $('#summary-correct').text(correctBets);
+            $('#summary-bets').text(totalBets.toLocaleString('en-GB'));
+            $('#summary-correct').text(correctBets.toLocaleString('en-GB'));
 
             const plDisplay = formatPL(totalPL);
             const plEl = $('#summary-pl');

--- a/uo-histf.html
+++ b/uo-histf.html
@@ -977,7 +977,7 @@
 
           // --- Summary update ---
           function updateSummary() {
-            const rows = table.rows({ filter: 'applied' }).data();
+            const rows = table.rows({ search: 'applied' }).data();
             const totalBets = rows.length;
 
             let correctBets = 0;
@@ -986,14 +986,15 @@
             for (let i = 0; i < rows.length; i++) {
               const row = rows[i];
 
-              // Correct? column (HTML with FA icon)
-              const correctHtml = row[11] || "";
-              if (typeof correctHtml === "string" && correctHtml.indexOf("fa-circle-check") !== -1) {
+              // Correct? column (last column, HTML icon or text fallback)
+              const correctCol = row[9] || "";
+              const correctHtml = String(correctCol).toLowerCase();
+              if (correctHtml.includes('fa-circle-check') || correctHtml.includes('correct') || correctHtml.includes('✅') || correctHtml.includes('✔') || correctHtml.includes('✓')) {
                 correctBets++;
               }
 
               // P/L column
-              const plCol = row[10];
+              const plCol = row[8];
               let plVal = 0;
               if (plCol && typeof plCol.sort !== "undefined") {
                 plVal = plCol.sort;
@@ -1003,8 +1004,8 @@
               totalPL += plVal;
             }
 
-            $('#summary-bets').text(totalBets);
-            $('#summary-correct').text(correctBets);
+            $('#summary-bets').text(totalBets.toLocaleString('en-GB'));
+            $('#summary-correct').text(correctBets.toLocaleString('en-GB'));
 
             const plDisplay = formatPL(totalPL);
             const plEl = $('#summary-pl');


### PR DESCRIPTION
### Motivation
- The recent compact table redesign changed column layout and rendering, which caused the summary/stat cards (Bets, Correct, Profit/Loss) to read stale/incorrect columns and report 0 values despite visible settled rows. 
- The goal is to make summary aggregation resilient to the new table structure and to ensure it always computes from the currently filtered dataset.

### Description
- Updated summary aggregation to use the DataTables filtered dataset scope via `rows({ search: 'applied' }).data()` so counts and sums reflect active filters/searches across the whole filtered set. 
- Adjusted column access to match the compact table layout (use `row[8]` for `P/L` and `row[9]` for `Correct?`) and made P/L extraction robust to either a `{ sort }` value or displayed text parsed by `parseCurrencyToNumber`. 
- Made the `Correct` detection tolerant of HTML icon variations and text by normalising the cell and checking for `fa-circle-check`, `correct`, `✅`, `✔`, `✓` etc., instead of relying on a brittle single marker. 
- Formatted `Bets` and `Correct` summary numbers with locale separators and preserved existing PL formatting, color treatment, filters, sorting, pagination and the new visual theme.

### Testing
- Inspected and validated the updated logic in all four pages (`hda-histf.html`, `hda-histd.html`, `uo-histf.html`, `uo-histd.html`) using code searches and excerpts with `rg`, `sed` and `nl` to confirm the new `rows({ search: 'applied' })` scope and column index usage, and these inspections succeeded. 
- Verified the summary updater remains bound to the DataTables `draw` event and is invoked on initial render so summary values refresh after filtering and date-range changes. 
- Confirmed `Correct` counting now recognises icon/text variants and that `P/L` sums use the numeric `sort` value when available or a robust currency parser as fallback. 
- Applied the same fix across all four historical pages and verified the updated code snippets are present in each file (inspections succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e671d9a0832fae7cf4cf95b1fd01)