### PR TITLE
Fix historical table filters and summary recalculation

### DIFF
--- a/hda-histd.html
+++ b/hda-histd.html
@@ -725,16 +725,16 @@
         <!-- Filter controls -->
         <div class="filter-title">Filter options</div>
         <div class="filters" id="prediction-filters">
-          <button data-pred="HOME WIN">Home Win</button>
-          <button data-pred="AWAY WIN">Away Win</button>
+          <button data-prediction-filter="home-win">Home Win</button>
+          <button data-prediction-filter="away-win">Away Win</button>
         </div>
         <div class="filters" id="value-filters">
-          <button data-val="❌">❌</button>
-          <button data-val="❌❌">❌❌</button>
-          <button data-val="❌❌❌">❌❌❌</button>
-          <button data-val="💰">💰</button>
-          <button data-val="💰💰">💰💰</button>
-          <button data-val="💰💰💰">💰💰💰</button>
+          <button data-value-filter="cross-1">❌</button>
+          <button data-value-filter="cross-2">❌❌</button>
+          <button data-value-filter="cross-3">❌❌❌</button>
+          <button data-value-filter="money-1">💰</button>
+          <button data-value-filter="money-2">💰💰</button>
+          <button data-value-filter="money-3">💰💰💰</button>
         </div>
 
         <!-- DataTable -->
@@ -813,12 +813,12 @@
     function normaliseValueCategory(value){
       const text = stripHtml(value).toLowerCase();
       if (!text) return "";
-      if (text.includes("💰💰💰") || text.includes("strong") || text.includes("high value")) return "money-3";
-      if (text.includes("💰💰") || text.includes("medium")) return "money-2";
-      if (text.includes("💰") || text.includes("small")) return "money-1";
-      if (text.includes("❌❌❌") || text.includes("large negative")) return "cross-3";
-      if (text.includes("❌❌") || text.includes("medium negative")) return "cross-2";
-      if (text.includes("❌") || text.includes("negative") || text.includes("no value")) return "cross-1";
+      if (text.includes("💰💰💰") || text.includes("money-3") || text.includes("strong") || text.includes("high value")) return "money-3";
+      if (text.includes("💰💰") || text.includes("money-2") || text.includes("medium")) return "money-2";
+      if (text.includes("💰") || text.includes("money-1") || text.includes("small")) return "money-1";
+      if (text.includes("❌❌❌") || text.includes("cross-3") || text.includes("large negative")) return "cross-3";
+      if (text.includes("❌❌") || text.includes("cross-2") || text.includes("medium negative")) return "cross-2";
+      if (text.includes("❌") || text.includes("cross-1") || text.includes("negative") || text.includes("no value")) return "cross-1";
       return "";
     }
 
@@ -959,7 +959,7 @@
           $.fn.dataTable.ext.search.push(historicalTableFilter);
 
           $('#prediction-filters button').on('click', function(){
-            const next = normalisePrediction($(this).data('pred'));
+            const next = String($(this).data('prediction-filter') || '').trim();
             const isActive = historyFilterState.prediction === next;
             historyFilterState.prediction = isActive ? null : next;
             $('#prediction-filters button').removeClass('active');
@@ -968,7 +968,7 @@
           });
 
           $('#value-filters button').on('click', function(){
-            const next = String($(this).data('val') || '').trim();
+            const next = String($(this).data('value-filter') || '').trim();
             const isActive = historyFilterState.valueCategory === next;
             historyFilterState.valueCategory = isActive ? null : next;
             $('#value-filters button').removeClass('active');

--- a/hda-histf.html
+++ b/hda-histf.html
@@ -726,16 +726,16 @@
         <!-- Filter controls -->
         <div class="filter-title">Filter options</div>
         <div class="filters" id="prediction-filters">
-          <button data-pred="HOME WIN">Home Win</button>
-          <button data-pred="AWAY WIN">Away Win</button>
+          <button data-prediction-filter="home-win">Home Win</button>
+          <button data-prediction-filter="away-win">Away Win</button>
         </div>
         <div class="filters" id="value-filters">
-          <button data-val="❌">❌</button>
-          <button data-val="❌❌">❌❌</button>
-          <button data-val="❌❌❌">❌❌❌</button>
-          <button data-val="💰">💰</button>
-          <button data-val="💰💰">💰💰</button>
-          <button data-val="💰💰💰">💰💰💰</button>
+          <button data-value-filter="cross-1">❌</button>
+          <button data-value-filter="cross-2">❌❌</button>
+          <button data-value-filter="cross-3">❌❌❌</button>
+          <button data-value-filter="money-1">💰</button>
+          <button data-value-filter="money-2">💰💰</button>
+          <button data-value-filter="money-3">💰💰💰</button>
         </div>
 
         <!-- DataTable -->
@@ -814,12 +814,12 @@
     function normaliseValueCategory(value){
       const text = stripHtml(value).toLowerCase();
       if (!text) return "";
-      if (text.includes("💰💰💰") || text.includes("strong") || text.includes("high value")) return "money-3";
-      if (text.includes("💰💰") || text.includes("medium")) return "money-2";
-      if (text.includes("💰") || text.includes("small")) return "money-1";
-      if (text.includes("❌❌❌") || text.includes("large negative")) return "cross-3";
-      if (text.includes("❌❌") || text.includes("medium negative")) return "cross-2";
-      if (text.includes("❌") || text.includes("negative") || text.includes("no value")) return "cross-1";
+      if (text.includes("💰💰💰") || text.includes("money-3") || text.includes("strong") || text.includes("high value")) return "money-3";
+      if (text.includes("💰💰") || text.includes("money-2") || text.includes("medium")) return "money-2";
+      if (text.includes("💰") || text.includes("money-1") || text.includes("small")) return "money-1";
+      if (text.includes("❌❌❌") || text.includes("cross-3") || text.includes("large negative")) return "cross-3";
+      if (text.includes("❌❌") || text.includes("cross-2") || text.includes("medium negative")) return "cross-2";
+      if (text.includes("❌") || text.includes("cross-1") || text.includes("negative") || text.includes("no value")) return "cross-1";
       return "";
     }
 
@@ -960,7 +960,7 @@
           $.fn.dataTable.ext.search.push(historicalTableFilter);
 
           $('#prediction-filters button').on('click', function(){
-            const next = normalisePrediction($(this).data('pred'));
+            const next = String($(this).data('prediction-filter') || '').trim();
             const isActive = historyFilterState.prediction === next;
             historyFilterState.prediction = isActive ? null : next;
             $('#prediction-filters button').removeClass('active');
@@ -969,7 +969,7 @@
           });
 
           $('#value-filters button').on('click', function(){
-            const next = String($(this).data('val') || '').trim();
+            const next = String($(this).data('value-filter') || '').trim();
             const isActive = historyFilterState.valueCategory === next;
             historyFilterState.valueCategory = isActive ? null : next;
             $('#value-filters button').removeClass('active');

--- a/uo-histd.html
+++ b/uo-histd.html
@@ -726,16 +726,16 @@
         <div class="filter-title">Filter options</div>
         <div class="filters" id="prediction-filters">
           <!-- Match exact strings in column P -->
-          <button data-pred="UNDER 2.5">Under 2.5</button>
-          <button data-pred="OVER 2.5">Over 2.5</button>
+          <button data-prediction-filter="under-2.5">Under 2.5</button>
+          <button data-prediction-filter="over-2.5">Over 2.5</button>
         </div>
         <div class="filters" id="value-filters">
-          <button data-val="❌">❌</button>
-          <button data-val="❌❌">❌❌</button>
-          <button data-val="❌❌❌">❌❌❌</button>
-          <button data-val="💰">💰</button>
-          <button data-val="💰💰">💰💰</button>
-          <button data-val="💰💰💰">💰💰💰</button>
+          <button data-value-filter="cross-1">❌</button>
+          <button data-value-filter="cross-2">❌❌</button>
+          <button data-value-filter="cross-3">❌❌❌</button>
+          <button data-value-filter="money-1">💰</button>
+          <button data-value-filter="money-2">💰💰</button>
+          <button data-value-filter="money-3">💰💰💰</button>
         </div>
 
         <!-- DataTable -->
@@ -814,12 +814,12 @@
     function normaliseValueCategory(value){
       const text = stripHtml(value).toLowerCase();
       if (!text) return "";
-      if (text.includes("💰💰💰") || text.includes("strong") || text.includes("high value")) return "money-3";
-      if (text.includes("💰💰") || text.includes("medium")) return "money-2";
-      if (text.includes("💰") || text.includes("small")) return "money-1";
-      if (text.includes("❌❌❌") || text.includes("large negative")) return "cross-3";
-      if (text.includes("❌❌") || text.includes("medium negative")) return "cross-2";
-      if (text.includes("❌") || text.includes("negative") || text.includes("no value")) return "cross-1";
+      if (text.includes("💰💰💰") || text.includes("money-3") || text.includes("strong") || text.includes("high value")) return "money-3";
+      if (text.includes("💰💰") || text.includes("money-2") || text.includes("medium")) return "money-2";
+      if (text.includes("💰") || text.includes("money-1") || text.includes("small")) return "money-1";
+      if (text.includes("❌❌❌") || text.includes("cross-3") || text.includes("large negative")) return "cross-3";
+      if (text.includes("❌❌") || text.includes("cross-2") || text.includes("medium negative")) return "cross-2";
+      if (text.includes("❌") || text.includes("cross-1") || text.includes("negative") || text.includes("no value")) return "cross-1";
       return "";
     }
 
@@ -960,7 +960,7 @@
           $.fn.dataTable.ext.search.push(historicalTableFilter);
 
           $('#prediction-filters button').on('click', function(){
-            const next = normalisePrediction($(this).data('pred'));
+            const next = String($(this).data('prediction-filter') || '').trim();
             const isActive = historyFilterState.prediction === next;
             historyFilterState.prediction = isActive ? null : next;
             $('#prediction-filters button').removeClass('active');
@@ -969,7 +969,7 @@
           });
 
           $('#value-filters button').on('click', function(){
-            const next = String($(this).data('val') || '').trim();
+            const next = String($(this).data('value-filter') || '').trim();
             const isActive = historyFilterState.valueCategory === next;
             historyFilterState.valueCategory = isActive ? null : next;
             $('#value-filters button').removeClass('active');

--- a/uo-histf.html
+++ b/uo-histf.html
@@ -726,16 +726,16 @@
         <div class="filter-title">Filter options</div>
         <div class="filters" id="prediction-filters">
           <!-- Use the exact strings present in column P of the sheet -->
-          <button data-pred="UNDER 2.5">Under 2.5</button>
-          <button data-pred="OVER 2.5">Over 2.5</button>
+          <button data-prediction-filter="under-2.5">Under 2.5</button>
+          <button data-prediction-filter="over-2.5">Over 2.5</button>
         </div>
         <div class="filters" id="value-filters">
-          <button data-val="❌">❌</button>
-          <button data-val="❌❌">❌❌</button>
-          <button data-val="❌❌❌">❌❌❌</button>
-          <button data-val="💰">💰</button>
-          <button data-val="💰💰">💰💰</button>
-          <button data-val="💰💰💰">💰💰💰</button>
+          <button data-value-filter="cross-1">❌</button>
+          <button data-value-filter="cross-2">❌❌</button>
+          <button data-value-filter="cross-3">❌❌❌</button>
+          <button data-value-filter="money-1">💰</button>
+          <button data-value-filter="money-2">💰💰</button>
+          <button data-value-filter="money-3">💰💰💰</button>
         </div>
 
         <!-- DataTable -->
@@ -814,12 +814,12 @@
     function normaliseValueCategory(value){
       const text = stripHtml(value).toLowerCase();
       if (!text) return "";
-      if (text.includes("💰💰💰") || text.includes("strong") || text.includes("high value")) return "money-3";
-      if (text.includes("💰💰") || text.includes("medium")) return "money-2";
-      if (text.includes("💰") || text.includes("small")) return "money-1";
-      if (text.includes("❌❌❌") || text.includes("large negative")) return "cross-3";
-      if (text.includes("❌❌") || text.includes("medium negative")) return "cross-2";
-      if (text.includes("❌") || text.includes("negative") || text.includes("no value")) return "cross-1";
+      if (text.includes("💰💰💰") || text.includes("money-3") || text.includes("strong") || text.includes("high value")) return "money-3";
+      if (text.includes("💰💰") || text.includes("money-2") || text.includes("medium")) return "money-2";
+      if (text.includes("💰") || text.includes("money-1") || text.includes("small")) return "money-1";
+      if (text.includes("❌❌❌") || text.includes("cross-3") || text.includes("large negative")) return "cross-3";
+      if (text.includes("❌❌") || text.includes("cross-2") || text.includes("medium negative")) return "cross-2";
+      if (text.includes("❌") || text.includes("cross-1") || text.includes("negative") || text.includes("no value")) return "cross-1";
       return "";
     }
 
@@ -960,7 +960,7 @@
           $.fn.dataTable.ext.search.push(historicalTableFilter);
 
           $('#prediction-filters button').on('click', function(){
-            const next = normalisePrediction($(this).data('pred'));
+            const next = String($(this).data('prediction-filter') || '').trim();
             const isActive = historyFilterState.prediction === next;
             historyFilterState.prediction = isActive ? null : next;
             $('#prediction-filters button').removeClass('active');
@@ -969,7 +969,7 @@
           });
 
           $('#value-filters button').on('click', function(){
-            const next = String($(this).data('val') || '').trim();
+            const next = String($(this).data('value-filter') || '').trim();
             const isActive = historyFilterState.valueCategory === next;
             historyFilterState.valueCategory = isActive ? null : next;
             $('#value-filters button').removeClass('active');


### PR DESCRIPTION
### Motivation
- Filtering on the historical pages produced zero rows after the initial load because UI filter values (button text or emojis) did not match the table rows' normalized keys, breaking the filtered-state summary recalculation.
- The intent is to ensure the same normalized row model is used end-to-end by the DataTable rows, custom filters and the summary cards so combined filters/search/date ranges produce correct results.

### Description
- Updated prediction buttons to use stable normalized attributes `data-prediction-filter` (e.g. `home-win`, `away-win`, `under-2.5`, `over-2.5`) and value buttons to use `data-value-filter` (`cross-1/2/3`, `money-1/2/3`) across `hda-histd`, `hda-histf`, `uo-histd`, and `uo-histf`.
- Aligned filter click handlers to read `data-prediction-filter` / `data-value-filter` and set the shared `historyFilterState`, then call `table.draw()` (no repeated pushes of `$.fn.dataTable.ext.search`).
- Expanded `normaliseValueCategory` to recognize both emoji/text labels and canonical keys (`money-*`, `cross-*`) so filtering and summary calculations operate on the same normalized values; left DataTables configuration, draw-based summary update and UI styling intact.

### Testing
- Verified attribute and handler updates with automated text searches using `rg` to ensure all `data-pred`/`data-val` usages were replaced by `data-prediction-filter` / `data-value-filter` and updated handler code; the searches returned the expected normalized keys.
- Committed the changes successfully with `git` and created the PR; the commit operation completed without error.
- No unit tests exist for the front-end filtering logic; manual runtime validation checklist (filters, date range, search and summary recalculation) is documented for acceptance testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ad26cf598832fa55b3d5e67c19648)