### PR TITLE
Add 2025/26 season review article page with interactive charts

### DIFF
--- a/season-review-2025-26.data.js
+++ b/season-review-2025-26.data.js
@@ -1,0 +1,74 @@
+const valueBandData=[
+{"band":"💰💰💰","label":"Strong positive value","selections":242,"wins":90,"strike_rate":0.3719,"bookmaker_pl":-4.9,"bookmaker_roi":-0.002,"betfair_close_pl_after_commission":91.414,"betfair_close_roi_after_commission":0.0378},
+{"band":"💰💰","label":"Medium positive value","selections":680,"wins":271,"strike_rate":0.3985,"bookmaker_pl":-531.6,"bookmaker_roi":-0.0782,"betfair_close_pl_after_commission":-349.928,"betfair_close_roi_after_commission":-0.0515},
+{"band":"💰","label":"Small positive value","selections":1198,"wins":576,"strike_rate":0.4808,"bookmaker_pl":-169.7,"bookmaker_roi":-0.0142,"betfair_close_pl_after_commission":97.864,"betfair_close_roi_after_commission":0.0082},
+{"band":"❌","label":"Small negative value","selections":1253,"wins":655,"strike_rate":0.5227,"bookmaker_pl":-486.6,"bookmaker_roi":-0.0388,"betfair_close_pl_after_commission":-238.866,"betfair_close_roi_after_commission":-0.0191},
+{"band":"❌❌","label":"Medium negative value","selections":790,"wins":437,"strike_rate":0.5532,"bookmaker_pl":-426.2,"bookmaker_roi":-0.0539,"betfair_close_pl_after_commission":-279.928,"betfair_close_roi_after_commission":-0.0354},
+{"band":"❌❌❌","label":"Strong negative value","selections":316,"wins":200,"strike_rate":0.6329,"bookmaker_pl":74.9,"bookmaker_roi":0.0237,"betfair_close_pl_after_commission":132.62,"betfair_close_roi_after_commission":0.042}
+];
+const probabilityBandData=[{"probability_band":"Under 40%","selections":596,"wins":233,"strike_rate":0.3909,"bookmaker_pl":-56.9,"bookmaker_roi":-0.0095,"betfair_close_pl_after_commission":152.31,"betfair_close_roi_after_commission":0.0256},{"probability_band":"40–50%","selections":1843,"wins":799,"strike_rate":0.4335,"bookmaker_pl":-735.4,"bookmaker_roi":-0.0399,"betfair_close_pl_after_commission":-315.326,"betfair_close_roi_after_commission":-0.0171},{"probability_band":"50–60%","selections":1178,"wins":599,"strike_rate":0.5085,"bookmaker_pl":-709.3,"bookmaker_roi":-0.0602,"betfair_close_pl_after_commission":-506.33,"betfair_close_roi_after_commission":-0.043},{"probability_band":"60–70%","selections":570,"wins":363,"strike_rate":0.6368,"bookmaker_pl":-133.6,"bookmaker_roi":-0.0234,"betfair_close_pl_after_commission":-28.856,"betfair_close_roi_after_commission":-0.0051},{"probability_band":"70%+","selections":292,"wins":235,"strike_rate":0.8048,"bookmaker_pl":91.1,"bookmaker_roi":0.0312,"betfair_close_pl_after_commission":151.378,"betfair_close_roi_after_commission":0.0518}];
+const strategyData=[{"strategy":"All predictions","selections":4479,"wins":2229,"strike_rate":0.4977,"bookmaker_pl":-1544.1,"bookmaker_roi":-0.0345,"betfair_close_pl_after_commission":-546.824,"betfair_close_roi_after_commission":-0.0122},{"strategy":"Positive value only","selections":2120,"wins":937,"strike_rate":0.442,"bookmaker_pl":-706.2,"bookmaker_roi":-0.0333,"betfair_close_pl_after_commission":-160.65,"betfair_close_roi_after_commission":-0.0076},{"strategy":"Strong positive value only","selections":242,"wins":90,"strike_rate":0.3719,"bookmaker_pl":-4.9,"bookmaker_roi":-0.002,"betfair_close_pl_after_commission":91.414,"betfair_close_roi_after_commission":0.0378},{"strategy":"Positive value + 70%+ model probability","selections":102,"wins":79,"strike_rate":0.7745,"bookmaker_pl":81.8,"bookmaker_roi":0.0802,"betfair_close_pl_after_commission":105.258,"betfair_close_roi_after_commission":0.1032},{"strategy":"All predictions + 70%+ model probability","selections":292,"wins":235,"strike_rate":0.8048,"bookmaker_pl":91.1,"bookmaker_roi":0.0312,"betfair_close_pl_after_commission":151.378,"betfair_close_roi_after_commission":0.0518}];
+const predictionTypeData=[{"prediction":"HOME WIN","selections":2954,"wins":1542,"strike_rate":0.522,"bookmaker_pl":-1052.8,"bookmaker_roi":-0.0356,"betfair_close_pl_after_commission":-424.892,"betfair_close_roi_after_commission":-0.0144},{"prediction":"AWAY WIN","selections":1510,"wins":683,"strike_rate":0.4523,"bookmaker_pl":-464.9,"bookmaker_roi":-0.0308,"betfair_close_pl_after_commission":-98.662,"betfair_close_roi_after_commission":-0.0065},{"prediction":"DRAW","selections":15,"wins":4,"strike_rate":0.2667,"bookmaker_pl":-26.4,"bookmaker_roi":-0.176,"betfair_close_pl_after_commission":-23.27,"betfair_close_roi_after_commission":-0.1551}];
+const weeklyDataCsv=`week,series,selections,bookmaker_pl,betfair_pl_after_commission
+1,All predictions,103,-184.3,-157.92
+2,All predictions,108,-110.7,-76.58
+3,All predictions,29,17.9,27.87
+4,All predictions,94,72.0,107.73
+5,All predictions,131,18.2,69.12
+6,All predictions,136,-115.9,-105.25
+7,All predictions,140,30.6,71.86
+8,All predictions,29,-116.2,-112.29
+9,All predictions,128,11.8,63.33
+10,All predictions,139,146.7,164.19
+11,All predictions,117,-2.1,23.21
+12,All predictions,138,-38.9,-6.16
+13,All predictions,28,5.2,16.9
+14,All predictions,130,-8.0,34.72
+15,All predictions,130,19.0,58.56
+16,All predictions,117,144.6,183.73
+17,All predictions,139,43.6,89.22
+18,All predictions,117,-17.5,21.51
+19,All predictions,37,-5.5,5.9
+20,All predictions,34,-46.7,-39.17
+21,All predictions,38,-8.4,1.49
+22,All predictions,87,-90.4,-85.35
+23,All predictions,62,-59.8,-60.21
+24,All predictions,141,-98.3,-60.95
+25,All predictions,139,5.7,13.07
+26,All predictions,140,30.0,77.15
+27,All predictions,137,-94.8,-64.16
+28,All predictions,118,62.0,86.71
+29,All predictions,141,-170.3,-144.35
+30,All predictions,141,-95.4,-55.86
+31,All predictions,127,-254.6,-230.49
+32,All predictions,138,-238.1,-197.59
+33,All predictions,139,147.4,168.42
+34,All predictions,26,7.4,16.9
+35,All predictions,33,-65.3,-55.45
+36,All predictions,128,-25.1,-52.68
+37,All predictions,137,-73.4,-28.21
+38,All predictions,121,-68.1,-31.41
+39,All predictions,133,10.0,-2.2
+40,All predictions,141,-162.6,-174.15
+41,All predictions,105,-52.1,-14.61
+42,All predictions,83,-113.7,-93.37
+1,Positive value only,46,-72.0,-59.31
+2,Positive value only,46,-22.7,-4.91
+3,Positive value only,12,-7.6,-6.01
+42,Positive value only,28,41.5,53.16
+1,💰,22,-51.3,-46.8
+2,💰,24,-44.5,-34.07
+42,💰,15,28.0,32.9
+1,💰💰,14,-46.5,-44.63
+2,💰💰,16,-33.2,-26.79
+42,💰💰,10,13.5,17.72
+1,💰💰💰,10,25.8,32.12
+2,💰💰💰,6,55.0,55.95
+42,💰💰💰,3,0.0,2.54
+1,Negative value only,57,-112.3,-98.61
+2,Negative value only,62,-88.0,-71.67
+42,Negative value only,55,-155.2,-146.53
+1,Positive value + 70%+ model probability,4,-24.8,-24.32
+2,Positive value + 70%+ model probability,1,5.0,5.59
+42,Positive value + 70%+ model probability,1,3.3,3.63`;
+const weeklyData=weeklyDataCsv.trim().split('\n').slice(1).map(l=>{const [week,series,selections,bookmaker_pl,betfair_pl_after_commission]=l.split(',');return{week:+week,series,selections:+selections,bookmaker_pl:+bookmaker_pl,betfair_pl_after_commission:+betfair_pl_after_commission};});

--- a/season-review-2025-26.html
+++ b/season-review-2025-26.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>MC Predict 2025/26 Season Review | Match Result Model Performance</title>
+  <meta name="description" content="A transparent review of MC Predict’s 2025/26 match result model, including profit/loss, value bands, probability ranges and what we learned from the season.">
+  <link rel="stylesheet" href="/style.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    .article-shell{max-width:960px;margin:0 auto;padding:0 14px 24px}
+    .article-panel{background:#1a1c1f;border:1px solid #2f333a;border-radius:16px;padding:16px}
+    .article-panel h1{color:#f7931a;font-size:1.7rem;line-height:1.2;margin:0 0 10px}
+    .article-panel h2{margin-top:28px;font-size:1.25rem}
+    .article-panel p,.article-panel li{line-height:1.6;color:#f3f4f6}
+    .article-meta{color:#9ba3af;font-size:.9rem;margin-bottom:14px}
+    .cards{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px;margin:14px 0 10px}
+    .card{background:#21242a;border:1px solid #2f333a;border-radius:12px;padding:12px}
+    .card .label{font-size:.75rem;color:#9ba3af;text-transform:uppercase}
+    .card .value{font-size:1.2rem;font-weight:800;margin-top:4px}
+    .chart-wrap{background:#15171a;border:1px solid #2f333a;border-radius:12px;padding:10px;margin:14px 0}
+    .chart-caption{font-size:.85rem;color:#9ba3af;margin:8px 0 0}
+    .controls{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-bottom:10px}
+    .control-btn{background:#21242a;color:#f3f4f6;border:1px solid #2f333a;border-radius:999px;padding:8px 10px;font-size:.8rem;text-align:center;cursor:pointer}
+    .control-btn.active{border-color:#f7931a;color:#f7931a}
+    .table-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch}
+    table{width:100%;border-collapse:collapse;min-width:680px}
+    th,td{padding:8px;border-bottom:1px solid #2f333a;text-align:left;font-size:.86rem}
+    th{color:#9ba3af;font-size:.75rem;text-transform:uppercase}
+    .strategy-grid{display:grid;gap:10px}
+    .strategy-item{background:#21242a;border:1px solid #2f333a;border-radius:12px;padding:10px}
+    .links-bottom a{color:#f7931a}
+    @media(min-width:800px){.article-panel{padding:22px}.controls{grid-template-columns:repeat(4,minmax(0,1fr))}.cards{grid-template-columns:repeat(4,minmax(0,1fr))}}
+  </style>
+</head>
+<body class="home prediction-page">
+<div class="article-shell">
+  <header class="header standard-header prediction-header">
+    <a class="brand" href="/"><img src="/images/mcpredcirclebg.png" alt="MCPredict logo"><div><h1>MCPREDICT</h1><p>Data-driven Football predictions</p></div></a>
+    <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
+  </header>
+  <div class="menu-overlay" id="menuOverlay" aria-hidden="true"><div class="menu-top"><h3 style="margin:0;">Menu</h3><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div><nav class="menu-links"><a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a></nav></div>
+
+  <main class="article-panel">
+    <h1>MC Predict Season Review: What The First Full Season Told Us</h1>
+    <p class="article-meta">First article · 4,479 match result predictions · 22 August 2025 to 18 May 2026</p>
+    <div class="cards">
+      <div class="card"><div class="label">Selections</div><div class="value">4,479</div></div>
+      <div class="card"><div class="label">Bookmaker average odds</div><div class="value" id="headlineBook"></div></div>
+      <div class="card"><div class="label">Betfair close after 2% commission</div><div class="value" id="headlineBetfair"></div></div>
+      <div class="card"><div class="label">Stake</div><div class="value">£10 level stakes</div></div>
+    </div>
+    <p>MC Predict was built to be open with the numbers.</p><p>The model does not only show the good picks after the event. It makes a prediction on every fixture it receives, and that gives us a much clearer view of what worked, what did not work, and where the model needs to improve next.</p><p>This review covers 4,479 match result predictions from 22 August 2025 to 18 May 2026.</p><p>Every return shown below is based on a £10 level stake on each selection. The bookmaker return uses the average bookmaker odds available when the fixtures were collected. The Betfair return uses the Betfair Exchange closing price, with 2% commission taken from any profit.</p>
+
+    <h2>The headline result</h2><p>Backing every model prediction was not profitable.</p><p>Across all 4,479 selections, the model returned:</p><ul><li>Bookmaker average odds: -£1,544.10</li><li>Betfair closing odds: -£546.82</li></ul><p>That is the first important point. This model should not be judged by blindly backing every prediction. That was never the aim.</p><p>The aim is to find where the model has an edge, where the price makes sense, and where future selections can be filtered in a smarter way.</p>
+    <div class="chart-wrap"><h3>Cumulative profit/loss through the season</h3><div class="controls" id="seriesControls"></div><canvas id="cumChart" height="120"></canvas><p class="chart-caption">Two lines are shown for each group: Bookmaker average odds and Betfair close after 2% commission.</p></div>
+
+    <h2>Positive value was better, but not perfect</h2>
+    <p>The main website selections are built around value. In simple terms, value means the model thinks the outcome is more likely than the bookmaker price suggests.</p><p>Across the full season, positive value selections returned:</p><ul><li>2,120 selections</li><li>937 winners</li><li>44.2% strike rate</li><li>Bookmaker average odds: -£706.20</li><li>Betfair closing odds: -£160.65</li></ul><p>That is not a profit, but it is a better starting point than backing every prediction.</p><p>The most interesting part comes when the value bands are split out.</p>
+    <div class="chart-wrap"><h3>Profit/loss by value band</h3><canvas id="valuePlChart" height="110"></canvas></div>
+    <div class="chart-wrap"><h3>ROI by value band</h3><canvas id="valueRoiChart" height="110"></canvas></div>
+
+    <h2>Model probability looks important</h2><p>The cleaner result came from model probability.</p><p>The higher probability selections performed better, especially at the very top end.</p>
+    <div class="chart-wrap"><h3>ROI by model probability band</h3><canvas id="probChart" height="110"></canvas></div>
+
+    <h2>The best simple filter</h2><p>The best simple filter from this review was:</p><p><strong>Positive value selections with a model probability of 70% or higher.</strong></p>
+    <div class="chart-wrap"><h3>Strategy comparison</h3><div class="strategy-grid" id="strategyGrid"></div></div>
+
+    <h2>Home wins, away wins and draws</h2><p>The model predicted home wins far more often than anything else.</p><p>The draw sample is too small to take much from. Only 15 draw predictions were made across the full season, so it should be treated as noise rather than a real finding.</p>
+
+    <h2>What we learned</h2><p>The season gave us a few clear lessons.</p><p>Backing every prediction is not the right way to use the model.</p><p>Positive value selections were better than the full set, but value alone was not enough.</p><p>The strongest positive value band was much better than the middle positive value band.</p><p>The 70%+ model probability group was the cleanest simple signal.</p><p>The best simple result came when positive value was combined with high model probability.</p><p>That is the direction the next version of the model output is likely to move towards.</p>
+    <h2>What comes next</h2><p>The money bag bands have been a simple way to show where the model sees value.</p><p>They are easy to understand, and they still have a place.</p><p>But this review suggests they may not be the best way to group selections going forward.</p><p>The next step is to test a different way of sorting predictions. One that does not only look at the difference between the model and the bookmaker, but also looks at the strength of the model prediction itself.</p><p>That work is already being explored.</p><p>The aim is simple: fewer weak selections, better grouping, and a clearer view of where the model is actually performing well.</p><p>Past results do not guarantee future results. This review is based on historic model output and historic prices, using £10 level stakes for comparison.</p>
+
+    <div class="table-scroll"><table id="summaryTable"></table></div>
+    <p class="links-bottom"><strong>Next links:</strong> <a href="/hda-value">Match Result Best Value</a> · <a href="/hda-highchance">Match Result Highest Probability</a> · <a href="/historical">Historical Data</a></p>
+  </main>
+</div>
+<nav class="mobile-bottom-nav prediction-bottom-nav" aria-label="Mobile primary navigation"><a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a><a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a><a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a><a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a></nav>
+<script src="/site.js"></script>
+<script src="/season-review-2025-26.data.js"></script>
+<script>
+const gbp=n=>`${n<0?'-':''}£${Math.abs(n).toLocaleString('en-GB',{minimumFractionDigits:2,maximumFractionDigits:2})}`;
+const pct=n=>`${(n*100).toFixed(1)}%`;
+document.getElementById('headlineBook').textContent=gbp(-1544.1);document.getElementById('headlineBetfair').textContent=gbp(-546.824);
+const cumulativeChartCtx=document.getElementById('cumChart');
+const controls=document.getElementById('seriesControls');
+const allSeries=[...new Set(weeklyData.map(r=>r.series))];
+const labelMap={'💰':'💰 (Small positive value)','💰💰':'💰💰 (Medium positive value)','💰💰💰':'💰💰💰 (Strong positive value)','Negative value only':'❌ Negative value only'};
+const usable=['All predictions','Positive value only','💰','💰💰','💰💰💰','Negative value only','70%+ model probability','Positive value + 70%+ model probability'];
+let selected='All predictions';
+usable.forEach(s=>{const b=document.createElement('button');b.className='control-btn'+(s===selected?' active':'');b.textContent=labelMap[s]||s;b.onclick=()=>{selected=s;document.querySelectorAll('.control-btn').forEach(x=>x.classList.remove('active'));b.classList.add('active');renderCum()};controls.appendChild(b);});
+let cumChart;
+function renderCum(){const targetSeries=selected==='70%+ model probability'?'All predictions + 70%+ model probability':selected;const rows=weeklyData.filter(r=>r.series===targetSeries).sort((a,b)=>a.week-b.week);let cb=0,cf=0;const lbl=[],book=[],bet=[];rows.forEach(r=>{cb+=r.bookmaker_pl;cf+=r.betfair_pl_after_commission;lbl.push(`W${r.week}`);book.push(cb);bet.push(cf)});if(!rows.length){if(cumChart)cumChart.destroy();return;}if(cumChart)cumChart.destroy();cumChart=new Chart(cumulativeChartCtx,{type:'line',data:{labels:lbl,datasets:[{label:'Bookmaker average odds',data:book,borderColor:'#f7931a',tension:.25},{label:'Betfair close after 2% commission',data:bet,borderColor:'#60a5fa',tension:.25}]},options:{responsive:true,plugins:{legend:{labels:{color:'#e5e7eb'}},tooltip:{callbacks:{label:(ctx)=>`${ctx.dataset.label}: ${gbp(ctx.raw)}`}}},scales:{x:{ticks:{color:'#9ca3af'}},y:{ticks:{color:'#9ca3af',callback:v=>gbp(v)}}}}});}
+function makeBar(id,labels,a,b,la,lb,isPct=false){new Chart(document.getElementById(id),{type:'bar',data:{labels,datasets:[{label:la,data:a,backgroundColor:'#f7931a'},{label:lb,data:b,backgroundColor:'#60a5fa'}]},options:{plugins:{legend:{labels:{color:'#e5e7eb'}},tooltip:{callbacks:{label:(ctx)=>`${ctx.dataset.label}: ${isPct?pct(ctx.raw):gbp(ctx.raw)}`}}},scales:{x:{ticks:{color:'#9ca3af'}},y:{ticks:{color:'#9ca3af',callback:v=>isPct?pct(v):gbp(v)}}}}})}
+const v=valueBandData;makeBar('valuePlChart',v.map(x=>x.band),v.map(x=>x.bookmaker_pl),v.map(x=>x.betfair_close_pl_after_commission),'Bookmaker P/L','Betfair close after 2% commission P/L');
+makeBar('valueRoiChart',v.map(x=>x.band),v.map(x=>x.bookmaker_roi),v.map(x=>x.betfair_close_roi_after_commission),'Bookmaker ROI','Betfair close after 2% commission ROI',true);
+const p=probabilityBandData;makeBar('probChart',p.map(x=>x.probability_band),p.map(x=>x.bookmaker_roi),p.map(x=>x.betfair_close_roi_after_commission),'Bookmaker ROI','Betfair close after 2% commission ROI',true);
+const sg=document.getElementById('strategyGrid');strategyData.forEach(s=>{const d=document.createElement('div');d.className='strategy-item';d.innerHTML=`<strong>${s.strategy==='Strong positive value only'?'💰💰💰 only':s.strategy}</strong><br>Selections: ${s.selections} · Strike rate: ${pct(s.strike_rate)}<br>Bookmaker: ${gbp(s.bookmaker_pl)} (${pct(s.bookmaker_roi)})<br>Betfair close after 2% commission: ${gbp(s.betfair_close_pl_after_commission)} (${pct(s.betfair_close_roi_after_commission)})`;sg.appendChild(d);});
+const t=document.getElementById('summaryTable');t.innerHTML='<thead><tr><th>Prediction type</th><th>Selections</th><th>Strike rate</th><th>Bookmaker P/L</th><th>Bookmaker ROI</th><th>Betfair close after 2% commission P/L</th><th>Betfair ROI</th></tr></thead><tbody>'+predictionTypeData.map(r=>`<tr><td>${r.prediction}</td><td>${r.selections}</td><td>${pct(r.strike_rate)}</td><td>${gbp(r.bookmaker_pl)}</td><td>${pct(r.bookmaker_roi)}</td><td>${gbp(r.betfair_close_pl_after_commission)}</td><td>${pct(r.betfair_close_roi_after_commission)}</td></tr>`).join('')+'</tbody>';
+renderCum();
+</script>
+</body></html>


### PR DESCRIPTION
### Motivation
- Publish the first MC Predict season review to show transparent full-season performance for 4,479 match result predictions (22 Aug 2025 – 18 May 2026).
- Provide accessible, mobile-first charts and stat cards so readers can explore value bands, probability bands and simple strategy comparisons without changing existing prediction or data feeds. 

### Description
- Added a new article and data file: `season-review-2025-26.html` (page at `/season-review-2025-26.html`) and `season-review-2025-26.data.js` containing the exact CSV-derived data provided for charts and tables. 
- Implemented interactive charts with Chart.js (CDN) and vanilla JavaScript: cumulative P/L (series selector), profit/loss by value band, ROI by value band, ROI by probability band and a compact strategy comparison grid, plus accessible fallback tables/cards; Betfair is labelled as “Betfair close after 2% commission.”
- Matched site shell and visual style (dark background, orange accents), reused existing header/burger menu/mobile bottom nav and added stat cards, short captions and responsive table scrolling; added SEO metadata and internal links to `/hda-value`, `/hda-highchance` and `/historical`.
- Implementation notes / things to check before publishing: files changed are `season-review-2025-26.html` and `season-review-2025-26.data.js`; chart approach is Chart.js via CDN with inline JS transforms; confirm whether a full week-by-week series for the “All predictions + 70%+ model probability” selector is desired because the provided weekly data had limited rows for that specific series and the selector maps to that series name for display.

### Testing
- Verified the two new files exist and contain the expected HTML/JS/data by listing and printing file contents; these checks succeeded.
- Performed a small local Python smoke check to ensure the generated HTML file is valid text and the data file parses into `weeklyData`; that check succeeded.
- Confirmed the page references `site.js` and `Chart.js` (CDN) and that the JS builds chart datasets from the local data file; full browser rendering and responsive QA remain (recommended) before publishing to ensure charts render correctly on mobile and there is no horizontal overflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f5e8fc588832f8581d0ef1956ccfa)