### PR TITLE
Fix season review chart sizing and restore standard header

### DIFF
--- a/season-review-2025-26.html
+++ b/season-review-2025-26.html
@@ -20,8 +20,9 @@
     .card .value{font-size:1.2rem;font-weight:800;margin-top:4px}
     .chart-wrap{background:#15171a;border:1px solid #2f333a;border-radius:12px;padding:10px;margin:14px 0}
     .chart-wrap canvas{display:block;width:100%}
-    .chart-cum{height:340px !important}
-    .chart-bar{height:280px !important}
+    .chart-cum,.chart-bar{height:auto !important}
+    .chart-wrap--cum{height:auto}
+    .chart-wrap--bar{height:auto}
     .chart-caption{font-size:.85rem;color:#9ba3af;margin:8px 0 0}
     .controls{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-bottom:10px}
     .control-btn{background:#21242a;color:#f3f4f6;border:1px solid #2f333a;border-radius:999px;padding:8px 10px;font-size:.8rem;text-align:center;cursor:pointer}
@@ -33,14 +34,14 @@
     .strategy-grid{display:grid;gap:10px}
     .strategy-item{background:#21242a;border:1px solid #2f333a;border-radius:12px;padding:10px}
     .links-bottom a{color:#f7931a}
-    @media(min-width:620px){.chart-cum{height:300px !important}.chart-bar{height:250px !important}}
-    @media(min-width:800px){.article-panel{padding:22px}.controls{grid-template-columns:repeat(4,minmax(0,1fr))}.cards{grid-template-columns:repeat(4,minmax(0,1fr))}.chart-cum{height:240px !important}.chart-bar{height:220px !important}}
+    @media(max-width:700px){.chart-wrap--cum{height:340px}.chart-wrap--bar{height:300px}}
+    @media(min-width:800px){.article-panel{padding:22px}.controls{grid-template-columns:repeat(4,minmax(0,1fr))}.cards{grid-template-columns:repeat(4,minmax(0,1fr))}}
   </style>
 </head>
 <body class="home prediction-page">
 <div class="article-shell">
   <header class="header standard-header prediction-header">
-    <a class="brand" href="/"><img src="/images/mcpredcirclebg.png" alt="MCPredict logo"><div><h1>MCPREDICT</h1><p>Data-driven Football predictions</p></div></a>
+    <a class="brand" href="/"><img src="/images/mcpredcirclebg.png" alt="MCPredict logo"><div><h1>MCPredict</h1><p>Data-driven Football predictions</p></div></a>
     <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
   </header>
   <div class="menu-overlay" id="menuOverlay" aria-hidden="true"><div class="menu-top"><h3 style="margin:0;">Menu</h3><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div><nav class="menu-links"><a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a></nav></div>
@@ -57,15 +58,15 @@
     <p>MC Predict was built to be open with the numbers.</p><p>The model does not only show the good picks after the event. It makes a prediction on every fixture it receives, and that gives us a much clearer view of what worked, what did not work, and where the model needs to improve next.</p><p>This review covers 4,479 match result predictions from 22 August 2025 to 18 May 2026.</p><p>Every return shown below is based on a £10 level stake on each selection. The bookmaker return uses the average bookmaker odds available when the fixtures were collected. The Betfair return uses the Betfair Exchange closing price, with 2% commission taken from any profit.</p>
 
     <h2>The headline result</h2><p>Backing every model prediction was not profitable.</p><p>Across all 4,479 selections, the model returned:</p><ul><li>Bookmaker average odds: -£1,544.10</li><li>Betfair closing odds: -£546.82</li></ul><p>That is the first important point. This model should not be judged by blindly backing every prediction. That was never the aim.</p><p>The aim is to find where the model has an edge, where the price makes sense, and where future selections can be filtered in a smarter way.</p>
-    <div class="chart-wrap"><h3>Cumulative profit/loss through the season</h3><div class="controls" id="seriesControls"></div><canvas id="cumChart" class="chart-cum" height="120"></canvas><p class="chart-caption">Two lines are shown for each group: Bookmaker average odds and Betfair close after 2% commission.</p></div>
+    <div class="chart-wrap chart-wrap--cum"><h3>Cumulative profit/loss through the season</h3><div class="controls" id="seriesControls"></div><canvas id="cumChart" class="chart-cum" height="120"></canvas><p class="chart-caption">Two lines are shown for each group: Bookmaker average odds and Betfair close after 2% commission.</p></div>
 
     <h2>Positive value was better, but not perfect</h2>
     <p>The main website selections are built around value. In simple terms, value means the model thinks the outcome is more likely than the bookmaker price suggests.</p><p>Across the full season, positive value selections returned:</p><ul><li>2,120 selections</li><li>937 winners</li><li>44.2% strike rate</li><li>Bookmaker average odds: -£706.20</li><li>Betfair closing odds: -£160.65</li></ul><p>That is not a profit, but it is a better starting point than backing every prediction.</p><p>The most interesting part comes when the value bands are split out.</p>
-    <div class="chart-wrap"><h3>Profit/loss by value band</h3><canvas id="valuePlChart" class="chart-bar" height="110"></canvas></div>
-    <div class="chart-wrap"><h3>ROI by value band</h3><canvas id="valueRoiChart" class="chart-bar" height="110"></canvas></div>
+    <div class="chart-wrap chart-wrap--bar"><h3>Profit/loss by value band</h3><canvas id="valuePlChart" class="chart-bar" height="110"></canvas></div>
+    <div class="chart-wrap chart-wrap--bar"><h3>ROI by value band</h3><canvas id="valueRoiChart" class="chart-bar" height="110"></canvas></div>
 
     <h2>Model probability looks important</h2><p>The cleaner result came from model probability.</p><p>The higher probability selections performed better, especially at the very top end.</p>
-    <div class="chart-wrap"><h3>ROI by model probability band</h3><canvas id="probChart" class="chart-bar" height="110"></canvas></div>
+    <div class="chart-wrap chart-wrap--bar"><h3>ROI by model probability band</h3><canvas id="probChart" class="chart-bar" height="110"></canvas></div>
 
     <h2>The best simple filter</h2><p>The best simple filter from this review was:</p><p><strong>Positive value selections with a model probability of 70% or higher.</strong></p>
     <div class="chart-wrap"><h3>Strategy comparison</h3><div class="strategy-grid" id="strategyGrid"></div></div>


### PR DESCRIPTION
### Motivation
- A recent global chart height change caused charts to appear vertically stretched on desktop and distorted on mobile, so desktop must revert to natural responsive sizing. 
- Mobile charts still need extra vertical room to remain readable above the bottom nav without distorting plotted data. 
- The season review header needed to match the site-wide standard header/branding so navigation and burger behaviour are consistent across pages.

### Description
- Updated `season-review-2025-26.html` to remove forced desktop chart heights by replacing `.chart-cum` and `.chart-bar` fixed heights with natural `height:auto` rules. 
- Added mobile-only wrapper classes `.chart-wrap--cum` and `.chart-wrap--bar` and a `@media (max-width:700px)` rule that sets mobile heights (`340px` for cumulative, `300px` for bar charts) so only small screens gain extra vertical space. 
- Applied the new wrapper classes to the cumulative/value/ROI chart containers and aligned the top branding text to the standard site style by changing the header `h1` casing to `MCPredict`. 
- Left Chart.js setup, `maintainAspectRatio` usage, break-even dotted dataset, chart data arrays, filters, profit/loss calculations and the mobile bottom navigation unchanged.

### Testing
- Ran repository inspections with `rg --files` and `rg -n` to locate header usage and verify no unexpected files were modified, and these commands completed successfully. 
- Verified the exact markup/CSS changes with `sed -n` and `nl -ba` to inspect `season-review-2025-26.html`, and the outputs confirmed only the intended chart/header edits. 
- Produced a `git diff` and committed the change with `git commit`, and the diff/commit completed successfully. 
- Note: visual rendering checks in a browser were not run by these automated commands in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6d7e5b94832f87cf420b6d7aa5ad)