### PR TITLE
Centralize burger menu navigation with shared menu-config.js

### DIFF
--- a/Test.html
+++ b/Test.html
@@ -240,14 +240,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        <a href="/hda-value">Match Result - Value</a>
-        <a href="/hda-highchance">Match Result - High Chance</a>
-        <a href="/uo-value">U/O 2.5 - Value</a>
-        <a href="/uo-highchance">U/O 2.5 - High Chance</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <section class="hero">

--- a/faqs.html
+++ b/faqs.html
@@ -32,17 +32,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
   <section class="hero hero--left">
@@ -96,6 +86,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -28,17 +28,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="prediction-tabs" role="tablist" aria-label="View switch">
@@ -82,6 +72,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 
   <script>

--- a/hda-histd.html
+++ b/hda-histd.html
@@ -661,14 +661,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical" class="active">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="sub-nav-pills" aria-label="Odds format views">
@@ -1095,6 +1088,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/hda-histf.html
+++ b/hda-histf.html
@@ -662,14 +662,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical" class="active">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="sub-nav-pills" aria-label="Odds format views">
@@ -1096,6 +1089,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/hda-value.html
+++ b/hda-value.html
@@ -29,17 +29,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="prediction-tabs" role="tablist" aria-label="View switch">
@@ -83,6 +73,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 
   <script>

--- a/historical.html
+++ b/historical.html
@@ -36,17 +36,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <!-- Main content -->
@@ -106,6 +96,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -236,17 +236,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <section class="hero">
@@ -627,6 +617,7 @@
       }
     })();
   </script>
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/lucky-dip.html
+++ b/lucky-dip.html
@@ -36,17 +36,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        <a href="/">Home</a>
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        <a href="/lucky-dip">Lucky Dip</a>
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <!-- Under construction content -->
@@ -80,6 +70,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/menu-config.js
+++ b/menu-config.js
@@ -1,0 +1,11 @@
+window.MCP_NAV_ITEMS = [
+  { label: 'Home', href: '/' },
+  { label: 'Match Result - Best Value', href: '/hda-value' },
+  { label: 'Match Result - Highest Probability', href: '/hda-highchance' },
+  { label: 'U/O 2.5 - Best Value', href: '/uo-value' },
+  { label: 'U/O 2.5 - Highest Probability', href: '/uo-highchance' },
+  { label: 'Historical Data', href: '/historical' },
+  { label: '2025/26 Season Review', href: '/season-review-2025-26' },
+  { label: 'World Cup 2026 Game', href: '/wc26/' },
+  { label: 'FAQs', href: '/faqs' }
+];

--- a/season-review-2025-26.html
+++ b/season-review-2025-26.html
@@ -43,7 +43,7 @@
     <a class="brand" href="/"><img src="/images/mcpredcirclebg.png" alt="MCPredict logo"><div><h1>MCPredict</h1><p>Data-driven Football predictions</p></div></a>
     <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
   </header>
-  <div class="menu-overlay" id="menuOverlay" aria-hidden="true"><div class="menu-top"><h3 style="margin:0;">Menu</h3><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div><nav class="menu-links"><a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a></nav></div>
+  <div class="menu-overlay" id="menuOverlay" aria-hidden="true"><div class="menu-top"><h3 style="margin:0;">Menu</h3><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div><nav class="menu-links"></nav></div>
 
   <main class="article-panel">
     <h1>MC Predict Season Review: What The First Full Season Told Us</h1>
@@ -80,7 +80,8 @@
   </main>
 </div>
 <nav class="mobile-bottom-nav prediction-bottom-nav" aria-label="Mobile primary navigation"><a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a><a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a><a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a><a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a></nav>
-<script src="/site.js"></script>
+<script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
 <script src="/season-review-2025-26.data.js"></script>
 <script>
 const gbp=n=>`${n<0?'-':''}£${Math.abs(n).toLocaleString('en-GB',{minimumFractionDigits:2,maximumFractionDigits:2})}`;

--- a/site.js
+++ b/site.js
@@ -1,5 +1,10 @@
 (function(){
-  function normalize(path){ return (path||'/').replace(/\/+$/g,'').replace(/\.html$/,'') || '/'; }
+  function normalize(path){
+    const cleaned=((path||'/').split('?')[0].split('#')[0]||'/').replace(/\.html$/,'');
+    if(cleaned==='/'||cleaned==='/index'||cleaned==='/index.html') return '/';
+    if(cleaned==='') return '/';
+    return cleaned.replace(/\/+$/g,'') || '/';
+  }
   function sanitize(value){ return (value || '').trim(); }
 
   function csvToRows(text){
@@ -71,6 +76,34 @@
     return table;
   }
 
+  
+
+  function isActivePath(current, target){
+    if(target==='/wc26/') return current==='/wc26' || current.startsWith('/wc26/');
+    return current===normalize(target);
+  }
+
+  function renderGlobalMenu(){
+    const items=Array.isArray(window.MCP_NAV_ITEMS)?window.MCP_NAV_ITEMS:[];
+    const menuRoots=document.querySelectorAll('.menu-links');
+    if(!items.length||!menuRoots.length) return;
+    const current=normalize(window.location.pathname);
+    menuRoots.forEach((root)=>{
+      root.innerHTML='';
+      items.forEach((item)=>{
+        const link=document.createElement('a');
+        link.href=item.href;
+        link.textContent=item.label;
+        if(isActivePath(current, item.href)){
+          link.classList.add('active');
+          link.setAttribute('aria-current','page');
+          link.style.color='black';
+        }
+        root.appendChild(link);
+      });
+    });
+  }
+
   function initMenu(){/* unchanged */
     const overlay=document.getElementById('menuOverlay');
     const open=document.getElementById('openMenu');
@@ -79,6 +112,7 @@
     const openMenu=()=>{overlay.classList.add('open');overlay.setAttribute('aria-hidden','false');};
     const closeMenu=()=>{overlay.classList.remove('open');overlay.setAttribute('aria-hidden','true');};
     open.addEventListener('click',openMenu);close.addEventListener('click',closeMenu);
+    overlay.addEventListener('click',(e)=>{ if(e.target.closest('.menu-links a')) closeMenu(); });
     overlay.addEventListener('click',(e)=>{if(e.target===overlay) closeMenu();});
     document.addEventListener('keydown',(e)=>{if(e.key==='Escape'&&overlay.classList.contains('open')) closeMenu();});
   }
@@ -92,10 +126,6 @@
     document.querySelectorAll('.mobile-bottom-menu__item[data-nav-path]').forEach((item)=>{
       const target=normalize(item.dataset.navPath||item.getAttribute('href'));
       item.classList.toggle('mobile-bottom-menu__item--active', current===target);
-    });
-    document.querySelectorAll('.menu-links a[href]').forEach((item)=>{
-      const target=normalize(item.getAttribute('href'));
-      item.classList.toggle('active', current===target);
     });
 
     const trigger=document.getElementById('bottomMenuTrigger');
@@ -112,5 +142,5 @@
   }
 
   window.MCPredictPrediction = { csvToRows, extractRowData, renderPredictionCard, renderPredictionTable, sanitize };
-  document.addEventListener('DOMContentLoaded',()=>{initMenu();initBottomNav();});
+  document.addEventListener('DOMContentLoaded',()=>{renderGlobalMenu();initMenu();initBottomNav();});
 })();

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -28,17 +28,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="prediction-tabs" role="tablist" aria-label="View switch">
@@ -82,6 +72,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 
   <script>

--- a/uo-histd.html
+++ b/uo-histd.html
@@ -661,14 +661,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical" class="active">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="sub-nav-pills" aria-label="Odds format views">
@@ -1096,6 +1089,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/uo-histf.html
+++ b/uo-histf.html
@@ -661,14 +661,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical" class="active">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="sub-nav-pills" aria-label="Odds format views">
@@ -1096,6 +1089,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/uo-value.html
+++ b/uo-value.html
@@ -28,17 +28,7 @@
         <h3 style="margin:0;">Menu</h3>
         <button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24"><path d="M6 6l12 12M18 6l-12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
       </div>
-      <nav class="menu-links">
-        
-        <a href="/hda-value">Match Result - Best Value</a>
-        <a href="/hda-highchance">Match Result - Highest Probability</a>
-        <a href="/uo-value">U/O 2.5 - Best Value</a>
-        <a href="/uo-highchance">U/O 2.5 - Highest Probability</a>
-        <a href="/historical">Historical Data</a>
-        <a href="/faqs">FAQs</a>
-        
-        <a href="/wc26/">World Cup 2026 Game</a>
-      </nav>
+      <nav class="menu-links"></nav>
     </div>
 
     <div class="prediction-tabs" role="tablist" aria-label="View switch">
@@ -82,6 +72,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
   </nav>
 
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 
   <script>

--- a/wc26/halloffame/index.html
+++ b/wc26/halloffame/index.html
@@ -17,9 +17,7 @@
   </header>
   <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
     <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
-    <nav class="menu-links" aria-label="Primary">
-      <a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a>
-    </nav>
+    <nav class="menu-links" aria-label="Primary"></nav>
   </div>
 
 <main class='wrap wc26-page'>
@@ -105,6 +103,7 @@
       <a href='/wc26/rules/'>View Rules</a>
     </nav>
   </main>
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/wc26/payment/index.html
+++ b/wc26/payment/index.html
@@ -10,10 +10,9 @@
   </header>
   <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
     <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
-    <nav class="menu-links" aria-label="Primary">
-      <a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a>
-    </nav>
+    <nav class="menu-links" aria-label="Primary"></nav>
   </div>
 
-<main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/' class='active' aria-current='page'>Payment</a><a href='/wc26/rules/'>Rules</a><a href='/wc26/table/'>League Table</a><a href='/wc26/halloffame/'>Hall Of Fame</a></nav><section class='card'><h1>Make Payment</h1><p>Pay your entry fee to validate your MC Predict World Cup 2026 prediction game entry.</p><a class='btn' href='https://revolut.me/matthe8f40?currency=GBP&amount=1000' target='_blank' rel='noopener noreferrer'>Pay Now</a><ul><li><a href='/wc26/scores/'>Submit Predictions</a></li><li><a href='/wc26/'>Back to World Cup Menu</a></li></ul></section></main>  <script src="/site.js"></script>
+<main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/' class='active' aria-current='page'>Payment</a><a href='/wc26/rules/'>Rules</a><a href='/wc26/table/'>League Table</a><a href='/wc26/halloffame/'>Hall Of Fame</a></nav><section class='card'><h1>Make Payment</h1><p>Pay your entry fee to validate your MC Predict World Cup 2026 prediction game entry.</p><a class='btn' href='https://revolut.me/matthe8f40?currency=GBP&amount=1000' target='_blank' rel='noopener noreferrer'>Pay Now</a><ul><li><a href='/wc26/scores/'>Submit Predictions</a></li><li><a href='/wc26/'>Back to World Cup Menu</a></li></ul></section></main>  <script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
 </body></html>

--- a/wc26/rules/index.html
+++ b/wc26/rules/index.html
@@ -75,9 +75,7 @@
   </header>
   <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
     <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
-    <nav class="menu-links" aria-label="Primary">
-      <a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a>
-    </nav>
+    <nav class="menu-links" aria-label="Primary"></nav>
   </div>
 
 <main class='wrap'>
@@ -128,6 +126,7 @@
       </div>
     </section>
   </main>
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/wc26/scores/index.html
+++ b/wc26/scores/index.html
@@ -196,9 +196,7 @@
   </header>
   <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
     <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
-    <nav class="menu-links" aria-label="Primary">
-      <a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a>
-    </nav>
+    <nav class="menu-links" aria-label="Primary"></nav>
   </div>
 
 <main class="wc26-page">
@@ -513,6 +511,7 @@
 
     loadFixtures();
   </script>
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body>
 </html>

--- a/wc26/table/index.html
+++ b/wc26/table/index.html
@@ -10,10 +10,9 @@
   </header>
   <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
     <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
-    <nav class="menu-links" aria-label="Primary">
-      <a href="/hda-value">Match Result - Best Value</a><a href="/hda-highchance">Match Result - Highest Probability</a><a href="/uo-value">U/O 2.5 - Best Value</a><a href="/uo-highchance">U/O 2.5 - Highest Probability</a><a href="/historical">Historical Data</a><a href="/faqs">FAQs</a><a href="/wc26/">World Cup 2026 Game</a>
-    </nav>
+    <nav class="menu-links" aria-label="Primary"></nav>
   </div>
 
-<main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/'>Payment</a><a href='/wc26/rules/'>Rules</a><a href='/wc26/table/' class='active' aria-current='page'>League Table</a><a href='/wc26/halloffame/'>Hall Of Fame</a></nav><section class='card'><h1>League Table</h1><p>The league table will appear here once the World Cup 2026 prediction game begins.</p><p><a href='/wc26/scores/'>Submit Predictions</a> · <a href='/wc26/rules/'>Rules / FAQs</a> · <a href='/wc26/'>Back to World Cup Menu</a></p></section></main>  <script src="/site.js"></script>
+<main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/'>Payment</a><a href='/wc26/rules/'>Rules</a><a href='/wc26/table/' class='active' aria-current='page'>League Table</a><a href='/wc26/halloffame/'>Hall Of Fame</a></nav><section class='card'><h1>League Table</h1><p>The league table will appear here once the World Cup 2026 prediction game begins.</p><p><a href='/wc26/scores/'>Submit Predictions</a> · <a href='/wc26/rules/'>Rules / FAQs</a> · <a href='/wc26/'>Back to World Cup Menu</a></p></section></main>  <script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
 </body></html>


### PR DESCRIPTION
### Motivation
- Provide a single source of truth for the burger menu so updates only need to be made in one place. 
- Ensure the same burger menu appears site-wide including `/wc26/` and all World Cup sub-pages. 
- Preserve existing burger behaviour and styling while removing duplicated hardcoded link lists from individual pages.

### Description
- Added `menu-config.js` that exposes `window.MCP_NAV_ITEMS` with the full ordered list of burger menu items. 
- Updated `site.js` to dynamically render `.menu-links` from `window.MCP_NAV_ITEMS`, to normalise paths, and to mark the active item with `class="active"`, `aria-current="page"` and black text for readability on the orange active background. 
- Implemented `/wc26/` special-casing so `/wc26`, `/wc26/`, and all `/wc26/...` sub-pages map to the World Cup menu item, and preserved existing menu open/close, outside-click, and Escape key behaviour while also closing the menu when a menu link is clicked. 
- Removed hardcoded burger link lists from page HTML files and added an absolute `<script src="/menu-config.js"></script>` before `/site.js` on pages that contain the burger menu (including WC pages and sub-pages) so runtime injection populates the menu.

### Testing
- Ran a syntax check `node -c site.js` to verify the updated script is valid, which succeeded. 
- Searched the repo with `rg` to confirm the canonical labels exist only in `menu-config.js` and `.menu-links` containers in pages are now empty, which succeeded. 
- Executed the automated HTML patching/validation scripts used in the rollout to inject `menu-config.js` before `site.js` and to remove inline menu anchors, and verified the expected pages (including `/wc26/*`) now include `/menu-config.js` prior to `/site.js`. 
- Performed repo-wide searches for the old hardcoded menu labels to ensure they are not duplicated in page-level burger markup, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10230ecbb0832f813effe2d2772bb1)