### PR TITLE
Add live WC26 league table sourced from published Google Sheet CSV

### DIFF
--- a/wc26/table/index.html
+++ b/wc26/table/index.html
@@ -1,6 +1,106 @@
-<!doctype html><html lang='en'><head><meta charset='UTF-8'><meta name='viewport' content='width=device-width,initial-scale=1'><title>MC Predict | WC26 Table</title><link rel='stylesheet' href='/style.css'><style>:root{--border:rgba(255,255,255,.12)}body{margin:0;font-family:'Proxima Nova',Arial,sans-serif;color:#f4f4f4;background:radial-gradient(circle at top,#2a2c33 0%,#1b1c20 42%,#111214 100%)}.wrap{max-width:860px;margin:0 auto;padding:16px 14px 60px}.card{background:linear-gradient(145deg,rgba(48,49,56,.95),rgba(28,29,33,.95));border:1px solid var(--border);border-radius:16px;padding:18px}.section-nav{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 12px}.section-nav a{text-decoration:none;color:#d2d5db;background:#2a2c33;border:1px solid var(--border);border-radius:999px;padding:8px 12px;font-size:.82rem}.section-nav a.active{background:linear-gradient(135deg,#f7931a,var(--wc26-gold));border-color:rgba(247,147,26,.75)}</style>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>MC Predict | WC26 Table</title>
+  <link rel="stylesheet" href="/style.css">
+  <style>
+    :root { --border: rgba(255,255,255,.12); }
+    body {
+      margin: 0;
+      font-family: 'Proxima Nova', Arial, sans-serif;
+      color: #f4f4f4;
+      background: radial-gradient(circle at top,#2a2c33 0%,#1b1c20 42%,#111214 100%);
+    }
+    .wrap { max-width: 980px; margin: 0 auto; padding: 16px 14px 60px; }
+    .section-nav { display:flex; flex-wrap:wrap; gap:8px; margin:0 0 12px; }
+    .section-nav a { text-decoration:none; color:#d2d5db; background:#2a2c33; border:1px solid var(--border); border-radius:999px; padding:8px 12px; font-size:.82rem; }
+    .section-nav a.active { background:linear-gradient(135deg,#f7931a,var(--wc26-gold)); border-color:rgba(247,147,26,.75); color:#111; }
 
-</head><body class="wc26-theme">
+    .wc26-league-section {
+      background: linear-gradient(145deg, rgba(48,49,56,.95), rgba(28,29,33,.95));
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: 0 14px 30px rgba(0,0,0,.35);
+      padding: 18px;
+    }
+    .wc26-league-section h1 { margin: 0 0 10px; font-size: 1.35rem; }
+    .wc26-league-intro { margin: 0 0 14px; color: #bdbdbd; line-height: 1.45; }
+    .wc26-table-card {
+      background: linear-gradient(180deg, #2c2c2e 0%, #222224 100%);
+      border: 1px solid rgba(242,152,12,.24);
+      border-radius: 14px;
+      overflow: hidden;
+    }
+    .wc26-table-scroll {
+      width: 100%;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(242,152,12,.5) rgba(255,255,255,.08);
+    }
+    .wc26-table-scroll::-webkit-scrollbar { height: 8px; }
+    .wc26-table-scroll::-webkit-scrollbar-track { background: rgba(255,255,255,.08); }
+    .wc26-table-scroll::-webkit-scrollbar-thumb { background: rgba(242,152,12,.5); border-radius: 999px; }
+
+    .wc26-league-table {
+      width: 100%;
+      min-width: 480px;
+      border-collapse: collapse;
+      font-size: .87rem;
+    }
+    .wc26-league-table thead th {
+      text-align: left;
+      color: #f2980c;
+      font-weight: 700;
+      letter-spacing: .01em;
+      background: rgba(255,255,255,.03);
+      border-bottom: 1px solid rgba(255,255,255,.12);
+      padding: 10px 8px;
+      white-space: nowrap;
+    }
+    .wc26-league-table tbody td {
+      color: #d5d5d7;
+      border-bottom: 1px solid rgba(255,255,255,.08);
+      padding: 10px 8px;
+      white-space: nowrap;
+    }
+    .wc26-league-table tbody tr:hover { background: rgba(242,152,12,.06); }
+    .wc26-league-table tbody tr:last-child td { border-bottom: 0; }
+
+    .wc26-rank-gold { box-shadow: inset 0 0 0 1px rgba(255,215,0,.28), inset 0 0 20px rgba(255,215,0,.09); }
+    .wc26-rank-silver { box-shadow: inset 0 0 0 1px rgba(192,192,192,.28), inset 0 0 20px rgba(192,192,192,.09); }
+    .wc26-rank-bronze { box-shadow: inset 0 0 0 1px rgba(205,127,50,.32), inset 0 0 20px rgba(205,127,50,.09); }
+
+    .wc26-table-state {
+      margin: 12px;
+      border: 1px solid rgba(255,255,255,.12);
+      border-radius: 12px;
+      background: rgba(255,255,255,.03);
+      color: #bdbdbd;
+      padding: 14px;
+      text-align: center;
+      font-size: .93rem;
+      line-height: 1.35;
+    }
+    .wc26-table-state.error {
+      border-color: rgba(255,102,102,.45);
+      background: rgba(255,102,102,.08);
+      color: #ffcece;
+    }
+    .is-hidden { display: none !important; }
+
+    @media (max-width: 560px) {
+      .wrap { padding: 14px 10px 58px; }
+      .wc26-league-section { padding: 14px; }
+      .wc26-league-table { font-size: .8rem; }
+      .wc26-league-table thead th, .wc26-league-table tbody td { padding: 8px 6px; }
+      .wc26-table-state { margin: 10px; padding: 12px; font-size: .88rem; }
+    }
+  </style>
+</head>
+<body class="wc26-theme">
   <header class="standard-header">
     <a class="brand" href="/" aria-label="MC Predict home">
       <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
@@ -13,6 +113,152 @@
     <nav class="menu-links" aria-label="Primary"></nav>
   </div>
 
-<main class='wrap'><nav class='section-nav'><a href='/wc26/'>Menu</a><a href='/wc26/scores/'>Submit Predictions</a><a href='/wc26/payment/'>Payment</a><a href='/wc26/rules/'>Rules</a><a href='/wc26/table/' class='active' aria-current='page'>League Table</a><a href='/wc26/halloffame/'>Hall Of Fame</a></nav><section class='card'><h1>League Table</h1><p>The league table will appear here once the World Cup 2026 prediction game begins.</p><p><a href='/wc26/scores/'>Submit Predictions</a> · <a href='/wc26/rules/'>Rules / FAQs</a> · <a href='/wc26/'>Back to World Cup Menu</a></p></section></main>  <script src="/menu-config.js"></script>
+  <main class="wrap">
+    <nav class="section-nav" aria-label="World Cup section">
+      <a href="/wc26/">Menu</a><a href="/wc26/scores/">Submit Predictions</a><a href="/wc26/payment/">Payment</a><a href="/wc26/rules/">Rules</a><a href="/wc26/table/" class="active" aria-current="page">League Table</a><a href="/wc26/halloffame/">Hall Of Fame</a>
+    </nav>
+
+    <section class="wc26-league-section">
+      <h1>League Table</h1>
+      <p class="wc26-league-intro">Follow the World Cup 2026 prediction game standings as entries are scored throughout the tournament.</p>
+
+      <div class="wc26-table-card">
+        <div id="leagueLoading" class="wc26-table-state">Loading league table…</div>
+        <div id="leagueEmpty" class="wc26-table-state is-hidden">League table will appear here once entries have been scored.</div>
+        <div id="leagueError" class="wc26-table-state error is-hidden">Unable to load the league table right now. Please check again later.</div>
+
+        <div id="leagueTableWrap" class="wc26-table-scroll is-hidden">
+          <table class="wc26-league-table" id="leagueTable">
+            <thead><tr id="leagueHeaderRow"></tr></thead>
+            <tbody id="leagueBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=1983601487&single=true&output=csv';
+      const loadingEl = document.getElementById('leagueLoading');
+      const emptyEl = document.getElementById('leagueEmpty');
+      const errorEl = document.getElementById('leagueError');
+      const tableWrapEl = document.getElementById('leagueTableWrap');
+      const headerRowEl = document.getElementById('leagueHeaderRow');
+      const bodyEl = document.getElementById('leagueBody');
+
+      function setState(state) {
+        loadingEl.classList.toggle('is-hidden', state !== 'loading');
+        emptyEl.classList.toggle('is-hidden', state !== 'empty');
+        errorEl.classList.toggle('is-hidden', state !== 'error');
+        tableWrapEl.classList.toggle('is-hidden', state !== 'table');
+      }
+
+      function parseCsv(text) {
+        const rows = [];
+        let row = [];
+        let field = '';
+        let i = 0;
+        let inQuotes = false;
+
+        while (i < text.length) {
+          const char = text[i];
+          if (inQuotes) {
+            if (char === '"') {
+              if (text[i + 1] === '"') {
+                field += '"';
+                i += 2;
+                continue;
+              }
+              inQuotes = false;
+              i += 1;
+              continue;
+            }
+            field += char;
+            i += 1;
+            continue;
+          }
+
+          if (char === '"') { inQuotes = true; i += 1; continue; }
+          if (char === ',') { row.push(field); field = ''; i += 1; continue; }
+          if (char === '\n') { row.push(field); rows.push(row); row = []; field = ''; i += 1; continue; }
+          if (char === '\r') {
+            if (text[i + 1] === '\n') { i += 1; }
+            row.push(field); rows.push(row); row = []; field = ''; i += 1; continue;
+          }
+          field += char;
+          i += 1;
+        }
+
+        if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
+        return rows.filter(function (r) { return r.some(function (c) { return String(c || '').trim() !== ''; }); });
+      }
+
+      function topSix(row) {
+        const six = new Array(6).fill('');
+        for (let index = 0; index < 6; index += 1) {
+          six[index] = typeof row[index] === 'string' ? row[index] : '';
+        }
+        return six;
+      }
+
+      async function loadLeagueTable() {
+        setState('loading');
+        try {
+          const response = await fetch(CSV_URL + '&t=' + Date.now(), { cache: 'no-store' });
+          if (!response.ok) throw new Error('Network response was not ok');
+
+          const csvText = await response.text();
+          const rows = parseCsv(csvText);
+          const headerRow = topSix(rows[8] || []);
+          const dataRows = rows.slice(9).map(topSix).filter(function (row) { return row[1].trim() !== ''; });
+
+          if (!headerRow.some(function (cell) { return cell.trim() !== ''; })) {
+            setState('error');
+            return;
+          }
+
+          headerRowEl.innerHTML = '';
+          bodyEl.innerHTML = '';
+
+          headerRow.forEach(function (cell) {
+            const th = document.createElement('th');
+            th.scope = 'col';
+            th.textContent = cell;
+            headerRowEl.appendChild(th);
+          });
+
+          if (!dataRows.length) {
+            setState('empty');
+            return;
+          }
+
+          dataRows.forEach(function (row) {
+            const tr = document.createElement('tr');
+            const rank = row[0].trim();
+            if (rank === '1') tr.classList.add('wc26-rank-gold');
+            else if (rank === '2') tr.classList.add('wc26-rank-silver');
+            else if (rank === '3') tr.classList.add('wc26-rank-bronze');
+
+            row.forEach(function (cell) {
+              const td = document.createElement('td');
+              td.textContent = cell;
+              tr.appendChild(td);
+            });
+            bodyEl.appendChild(tr);
+          });
+
+          setState('table');
+        } catch (error) {
+          setState('error');
+        }
+      }
+
+      loadLeagueTable();
+    })();
+  </script>
+
+  <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
-</body></html>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a live, mobile-first league table on `/wc26/table/` that fetches the published Google Sheets CSV so standings update as entries are scored.
- Respect the sheet structure and game rules: ignore rows 1–8, use row 9 as the header, only show columns A–F, and only display rows where column B is populated.
- Preserve the existing MCPredict/WC26 header, navigation, and site scripts while matching the site’s dark, premium visual style with orange accents.
- Add tasteful visual emphasis for ranks 1–3 (gold, silver, bronze) and clear loading/empty/error states for users.

### Description
- Replaced the placeholder content in `wc26/table/index.html` with a new league table section that keeps the existing header/menu overlay and navigation and adds the suggested intro copy and a modern card layout.
- Added page-specific styling (classes including `.wc26-league-section`, `.wc26-table-card`, `.wc26-table-scroll`, `.wc26-league-table`, `.wc26-table-state`, `.wc26-rank-gold`, `.wc26-rank-silver`, and `.wc26-rank-bronze`) to match MCPredict visuals and support compact mobile spacing and polished horizontal scrolling.
- Implemented a robust client-side CSV parser that handles quoted values, escaped quotes, commas inside cells, CRLF line breaks, and blank rows, and uses `row 9` as the header while ignoring rows 1–8 and limiting output to columns A–F.
- Fetches the published CSV URL with cache-busting (`&t=${Date.now()}`), filters out rows where column B is blank, preserves the original sheet order (no client-side sorting), renders semantic table markup (`<table>`, `<thead>`, `<tbody>`, `<th>`, `<td>`), and applies gold/silver/bronze row classes based on the value in column A.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1811e84e64832fb7f1d7e14313e47f)