### PR TITLE
WC26: Preserve leading blank rows when parsing CSV

### DIFF
--- a/wc26/table/index.html
+++ b/wc26/table/index.html
@@ -191,7 +191,7 @@
         }
 
         if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
-        return rows.filter(function (r) { return r.some(function (c) { return String(c || '').trim() !== ''; }); });
+        return rows;
       }
 
       function topSix(row) {


### PR DESCRIPTION
### Motivation
- Ensure CSV parsing preserves leading blank rows so `rows[8]` maps to sheet row 9 (header) and `rows.slice(9)` maps to sheet row 10+ (data), fixing an empty-state render when the sheet contains top blank rows.

### Description
- In `wc26/table/index.html` updated `parseCsv` to return the complete `rows` array (preserving blank rows) instead of filtering out empty rows, while leaving the downstream header selection (`topSix(rows[8])`) and data filtering (`row[1].trim() !== ''`) unchanged.

### Testing
- Verified the repository diff shows the intended single-line change to `parseCsv` and the PR creation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1815a92960832fb912697e12387929)