### PR TITLE
WC26 league table: mobile layout — fit six columns and center headers/cells

### DIFF
--- a/wc26/table/index.html
+++ b/wc26/table/index.html
@@ -35,8 +35,7 @@
     }
     .wc26-table-scroll {
       width: 100%;
-      overflow-x: auto;
-      -webkit-overflow-scrolling: touch;
+      overflow-x: hidden;
       scrollbar-width: thin;
       scrollbar-color: rgba(242,152,12,.5) rgba(255,255,255,.08);
     }
@@ -46,12 +45,13 @@
 
     .wc26-league-table {
       width: 100%;
-      min-width: 480px;
+      min-width: 0;
       border-collapse: collapse;
+      table-layout: fixed;
       font-size: .87rem;
     }
     .wc26-league-table thead th {
-      text-align: left;
+      text-align: center;
       color: #f2980c;
       font-weight: 700;
       letter-spacing: .01em;
@@ -64,8 +64,26 @@
       color: #d5d5d7;
       border-bottom: 1px solid rgba(255,255,255,.08);
       padding: 10px 8px;
+      text-align: center;
       white-space: nowrap;
     }
+    .wc26-league-table th:nth-child(1),
+    .wc26-league-table td:nth-child(1) { width: 13%; }
+    .wc26-league-table th:nth-child(2),
+    .wc26-league-table td:nth-child(2) {
+      width: 42%;
+      white-space: normal;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+    .wc26-league-table th:nth-child(3),
+    .wc26-league-table td:nth-child(3),
+    .wc26-league-table th:nth-child(4),
+    .wc26-league-table td:nth-child(4),
+    .wc26-league-table th:nth-child(5),
+    .wc26-league-table td:nth-child(5),
+    .wc26-league-table th:nth-child(6),
+    .wc26-league-table td:nth-child(6) { width: 11.25%; }
     .wc26-league-table tbody tr:hover { background: rgba(242,152,12,.06); }
     .wc26-league-table tbody tr:last-child td { border-bottom: 0; }
 
@@ -94,8 +112,10 @@
     @media (max-width: 560px) {
       .wrap { padding: 14px 10px 58px; }
       .wc26-league-section { padding: 14px; }
-      .wc26-league-table { font-size: .8rem; }
-      .wc26-league-table thead th, .wc26-league-table tbody td { padding: 8px 6px; }
+      .wc26-league-table { font-size: .75rem; }
+      .wc26-league-table thead th, .wc26-league-table tbody td { padding: 7px 4px; }
+      .wc26-league-table th:nth-child(2),
+      .wc26-league-table td:nth-child(2) { line-height: 1.2; }
       .wc26-table-state { margin: 10px; padding: 12px; font-size: .88rem; }
     }
   </style>


### PR DESCRIPTION
### Motivation
- Ensure the WC26 six-column league table fits on small screens without horizontal scrolling while keeping the traditional table layout and all headers unchanged.
- Improve readability on mobile by making `NAME` the widest column and making stat columns compact and centered.

### Description
- Updated inline CSS in `wc26/table/index.html` to remove horizontal scrolling by setting `.wc26-table-scroll { overflow-x: hidden; }` and `table { min-width: 0; table-layout: fixed; }`.
- Center-aligned all headers and body cells by changing `thead th` and `tbody td` to `text-align: center` and added compact padding and reduced mobile font-size.
- Assigned percentage-based column widths so `RANK` is ~`13%`, `NAME` is ~`42%` (wrapping enabled with `white-space: normal`), and the remaining four stat columns share the rest at ~`11.25%` each.
- Preserved desktop appearance, the six-column structure, header labels, and the existing top-3 glow styles (`.wc26-rank-gold`, `.wc26-rank-silver`, `.wc26-rank-bronze`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181a1e7624832f974e124adc8b5eda)