### PR TITLE
WC26 scoring: make Correct Score card full-width on mobile

### DIFF
--- a/wc26/table/index.html
+++ b/wc26/table/index.html
@@ -60,6 +60,11 @@
       display: grid;
       gap: 3px;
     }
+    .wc26-scoring-item.featured {
+      border-color: rgba(242,152,12,.38);
+      background: linear-gradient(145deg, rgba(242,152,12,.12), rgba(255,255,255,.03));
+      box-shadow: inset 0 0 0 1px rgba(255,255,255,.05);
+    }
     .wc26-scoring-code {
       display: inline-flex;
       align-items: center;
@@ -168,11 +173,13 @@
 
     @media (min-width: 780px) {
       .wc26-scoring-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      .wc26-scoring-item.featured { grid-column: auto; }
     }
 
     @media (max-width: 560px) {
       .wrap { padding: 14px 10px 58px; }
       .wc26-league-section { padding: 14px; }
+      .wc26-scoring-item.featured { grid-column: 1 / -1; }
       .wc26-league-table { font-size: .75rem; }
       .wc26-league-table thead th, .wc26-league-table tbody td { padding: 7px 4px; }
       .wc26-league-table th:nth-child(2),
@@ -209,7 +216,7 @@
           <p>How your league table points are calculated.</p>
         </div>
         <div class="wc26-scoring-grid">
-          <article class="wc26-scoring-item">
+          <article class="wc26-scoring-item featured">
             <span class="wc26-scoring-code">CS</span>
             <span class="wc26-scoring-label">Correct Score</span>
             <span class="wc26-scoring-points">2 points for a correct score</span>


### PR DESCRIPTION
### Motivation
- The scoring cards stacked awkwardly on mobile because all three cards were treated equally, making the layout feel unbalanced.
- The Correct Score (CS) card should be visually prominent and span the full width on small screens while keeping the MR and U/O cards as two equal columns beneath it.
- Desktop/tablet layout must remain the existing three-column presentation.

### Description
- Added a modifier class `featured` and applied it to the CS card in `wc26/table/index.html` to allow targeted layout and styling for the primary card.
- Introduced `.wc26-scoring-item.featured` styles with a subtle gold-tinged gradient, adjusted border and inset highlight to give a slight premium emphasis without increasing height.
- Used CSS Grid rules so the scoring grid remains `repeat(3, minmax(0, 1fr))` at `min-width: 780px` and on small screens the featured card spans full width via `grid-column: 1 / -1` while the other two occupy the two equal columns.
- Kept spacing, gaps and overall theme styling consistent with the existing WC26 design by only adding minimal decorative adjustments.

### Testing
- Located and inspected relevant markup and styles using `rg` to ensure changes targeted the correct file and selectors, which succeeded.
- Updated `wc26/table/index.html` and verified the new class and CSS rules are present using `nl -ba ... | sed -n ...`, which showed the inserted `featured` class and media-query rules.
- Committed the change successfully to the repository, indicating the patch applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18278357f0832fbc6813fd5f29a92e)