### PR TITLE
Filter invalid spreadsheet values from WC26 predictions player dropdown

### DIFF
--- a/wc26/predictions/index.html
+++ b/wc26/predictions/index.html
@@ -281,6 +281,24 @@
         return String(value || '').replace(/^\uFEFF/, '').trim();
       }
 
+      function isSpreadsheetError(value) {
+        const cleaned = cleanCell(value).toUpperCase();
+        return [
+          '#REF!',
+          '#N/A',
+          '#VALUE!',
+          '#ERROR!',
+          '#DIV/0!',
+          '#NAME?',
+          '#NUM!'
+        ].includes(cleaned);
+      }
+
+      function isValidSheetValue(value) {
+        const cleaned = cleanCell(value);
+        return cleaned !== '' && !isSpreadsheetError(cleaned);
+      }
+
       function parseCsv(text) {
         const rows = [];
         let row = [];
@@ -323,6 +341,7 @@
 
       function buildLookup(rows) {
         const lookup = new Map();
+        const invalidNameSubmissionIds = new Set();
         const participantCount = Number.parseInt(cleanCell(rows[0] && rows[0][1]), 10);
         const scanLimit = Number.isFinite(participantCount) && participantCount > 0
           ? Math.max(rows.length, LOOKUP_START_ROW_INDEX + participantCount)
@@ -331,11 +350,16 @@
         for (let index = LOOKUP_START_ROW_INDEX; index < scanLimit; index += 1) {
           const row = rows[index] || [];
           const submissionId = cleanCell(row[2]);
-          if (!submissionId) continue;
-          lookup.set(submissionId, cleanCell(row[5]));
+          const playerName = cleanCell(row[5]);
+          if (!isValidSheetValue(submissionId)) continue;
+          if (isSpreadsheetError(playerName)) {
+            invalidNameSubmissionIds.add(submissionId);
+            continue;
+          }
+          lookup.set(submissionId, playerName);
         }
 
-        return lookup;
+        return { lookup, invalidNameSubmissionIds };
       }
 
       function buildFixtures(rows) {
@@ -355,14 +379,17 @@
           });
       }
 
-      function buildPlayers(predictionRows, lookup) {
+      function buildPlayers(predictionRows, lookupData) {
+        const lookup = lookupData.lookup;
+        const invalidNameSubmissionIds = lookupData.invalidNameSubmissionIds;
         const headerRow = predictionRows[0] || [];
         const nameCounts = new Map();
         const playerList = [];
 
         for (let columnIndex = FIRST_SUBMISSION_COLUMN_INDEX; columnIndex < headerRow.length; columnIndex += 1) {
           const submissionId = cleanCell(headerRow[columnIndex]);
-          if (!submissionId) continue;
+          if (!isValidSheetValue(submissionId)) continue;
+          if (invalidNameSubmissionIds.has(submissionId)) continue;
           const lookupName = cleanCell(lookup.get(submissionId));
           const name = lookupName || 'Unknown Player';
           nameCounts.set(name, (nameCounts.get(name) || 0) + 1);
@@ -445,10 +472,10 @@
           ]);
           const predictionRows = results[0];
           const lookupRows = results[1];
-          const lookup = buildLookup(lookupRows);
+          const lookupData = buildLookup(lookupRows);
 
           fixtures = buildFixtures(predictionRows);
-          players = buildPlayers(predictionRows, lookup);
+          players = buildPlayers(predictionRows, lookupData);
 
           if (!players.length) {
             playerSelectEl.innerHTML = '<option>No players found</option>';


### PR DESCRIPTION
### Motivation

- The player dropdown on `/wc26/predictions/` was including spreadsheet error values like `#REF! (#REF!)`, which are invalid and must be removed.
- Filter out missing/blank/error submission IDs and spreadsheet-error player names while still supporting valid unknown players and duplicate names.
- Preserve existing UX: alphabetical sorting, showing `Unknown Player (Submission ID)` when appropriate, duplicate labels with submission IDs, and automatic selection of the first valid player.

### Description

- Added `isSpreadsheetError` and `isValidSheetValue` helper functions and used `cleanCell` for trimming and normalization. 
- Updated `buildLookup` to ignore invalid/blank submission IDs and to track submission IDs whose lookup name is a spreadsheet error, returning `{ lookup, invalidNameSubmissionIds }`.
- Updated `buildPlayers` to accept the `lookupData`, skip invalid submission IDs and any submission IDs flagged for invalid lookup names, and to continue to name/label, sort, and render players as before.
- Changes are limited to `wc26/predictions/index.html` and do not modify any other pages, menus, or shared styling.

### Testing

- Ran a Node VM smoke test with mocked CSV data that confirmed spreadsheet error values are excluded, duplicate valid names keep submission IDs, valid unknown submission IDs remain, and the first alphabetical player is auto-selected (passed).
- Ran `git diff --check` to validate formatting and whitespace (passed).
- Verified `wc26/predictions/index.html` still renders predictions for selected valid players via the existing rendering logic (smoke checked in the VM test and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f02d18c80832fa02c24c5a65ced5d)