### PR TITLE
Limit WC26 predictions to rows 2–73

### DIFF
--- a/wc26/predictions/index.html
+++ b/wc26/predictions/index.html
@@ -257,6 +257,7 @@
       const LOOKUP_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=729356436&single=true&output=csv';
       const FIRST_SUBMISSION_COLUMN_INDEX = 5;
       const LOOKUP_START_ROW_INDEX = 15;
+      const LAST_FIXTURE_ROW_EXCLUSIVE_INDEX = 73;
 
       const playerSelectEl = document.getElementById('playerSelect');
       const loadingEl = document.getElementById('predictionsLoading');
@@ -363,7 +364,7 @@
       }
 
       function buildFixtures(rows) {
-        return rows.slice(1)
+        return rows.slice(1, LAST_FIXTURE_ROW_EXCLUSIVE_INDEX)
           .filter(function (row) {
             return row.slice(0, 5).some(function (cell) { return cleanCell(cell) !== ''; });
           })


### PR DESCRIPTION
### Motivation
- Ensure the predictions table only displays fixture rows from spreadsheet row 2 through row 73 while continuing to read submission IDs from spreadsheet row 1 (column F onward).

### Description
- Add `const LAST_FIXTURE_ROW_EXCLUSIVE_INDEX = 73` and update `buildFixtures` to use `rows.slice(1, LAST_FIXTURE_ROW_EXCLUSIVE_INDEX)` so fixture rows and player score cells are limited to spreadsheet rows 2–73.

### Testing
- Ran `git diff --check`, static assertions via `python3 - <<'PY'` to verify the new constant and slice usage, and served the site locally with `python3 -m http.server` then fetched `/wc26/predictions/` with `curl`; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f048d3dcc832fb12ca778454ba10a)