### PR TITLE
Add WC26 AI prediction section with table, Meet the AI, and predictions shell

### DIFF
--- a/wc26/ai/ai.css
+++ b/wc26/ai/ai.css
@@ -1,0 +1,428 @@
+body.wc26-theme.wc26-ai-body {
+  margin: 0;
+  color: #f3f4f6;
+  background: radial-gradient(circle at top, #2c2c2e 0%, #1d1d20 42%, #141417 100%);
+}
+
+.wc26-ai-page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0 14px 60px;
+}
+
+.wc26-ai-page .section-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.wc26-ai-page .section-nav a {
+  text-decoration: none;
+  color: #d2d5db;
+  background: #24262b;
+  border: 1px solid var(--wc26-border, rgba(255,255,255,.12));
+  border-radius: 999px;
+  padding: 8px 12px;
+  font-size: .82rem;
+}
+
+.wc26-ai-page .section-nav a.active,
+.wc26-ai-page .section-nav a[aria-current="page"] {
+  color: #111 !important;
+  background: linear-gradient(135deg, #f7931a, var(--wc26-gold, #f4b244));
+  border-color: rgba(247,147,26,.75);
+  box-shadow: 0 0 16px rgba(244,178,68,.22);
+}
+
+.wc26-ai-page .hero,
+.wc26-ai-page .card,
+.wc26-ai-page .wc26-league-section {
+  background: linear-gradient(145deg, rgba(47,49,54,.95), rgba(27,28,31,.96));
+  border: 1px solid var(--wc26-border, rgba(255,255,255,.12));
+  box-shadow: 0 14px 30px rgba(0,0,0,.35);
+}
+
+.wc26-ai-page .hero,
+.wc26-ai-page .card,
+.wc26-ai-page .wc26-league-section {
+  border-radius: 16px;
+}
+
+.wc26-ai-page .hero {
+  padding: 22px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.wc26-ai-page .hero h1,
+.wc26-ai-page .wc26-league-section h1 {
+  margin: 0 0 10px;
+  color: #fff;
+  font-size: clamp(1.6rem, 6vw, 2.45rem);
+  line-height: 1.1;
+}
+
+.wc26-ai-page .subtitle,
+.wc26-ai-page .note,
+.wc26-ai-page .wc26-league-intro {
+  color: var(--wc26-muted, #bdbdbd);
+  line-height: 1.5;
+}
+
+.wc26-ai-page .subtitle {
+  max-width: 760px;
+  margin: 0 auto 12px;
+  font-size: 1rem;
+}
+
+.wc26-ai-page .note {
+  display: inline-block;
+  margin: 4px 0 0;
+  padding: 8px 12px;
+  border: 1px solid rgba(242,152,12,.28);
+  border-radius: 999px;
+  background: rgba(242,152,12,.08);
+  font-size: .88rem;
+}
+
+.wc26-ai-page .eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 0 10px;
+  padding: 5px 10px;
+  border: 1px solid rgba(242,152,12,.38);
+  border-radius: 999px;
+  color: var(--wc26-gold, #f4b244);
+  background: rgba(242,152,12,.08);
+  font-size: .74rem;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.wc26-ai-page .grid,
+.wc26-ai-page .entrant-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+
+.wc26-ai-page .card {
+  padding: 18px;
+}
+
+.wc26-ai-page .nav-card,
+.wc26-ai-page .entrant-card,
+.wc26-ai-page .coming-soon-card {
+  display: block;
+  color: #f3f4f6;
+  background: linear-gradient(145deg, rgba(255,255,255,.055), rgba(255,255,255,.025));
+  border: 1px solid var(--wc26-border, rgba(255,255,255,.12));
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(0,0,0,.22);
+}
+
+.wc26-ai-page .nav-card {
+  position: relative;
+  min-height: 142px;
+  padding: 18px;
+  overflow: hidden;
+  text-decoration: none;
+  transition: transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+}
+
+.wc26-ai-page .nav-card::before,
+.wc26-ai-page .entrant-card::before,
+.wc26-ai-page .coming-soon-card::before {
+  content: "";
+  display: block;
+  height: 3px;
+  margin: -18px -18px 16px;
+  background: linear-gradient(90deg, #f7931a, rgba(244,178,68,.25));
+}
+
+.wc26-ai-page .nav-card:hover,
+.wc26-ai-page .nav-card:focus-visible {
+  text-decoration: none;
+  border-color: rgba(244,178,68,.55);
+  transform: translateY(-1px);
+  box-shadow: 0 0 18px rgba(244,178,68,.18), 0 12px 26px rgba(0,0,0,.28);
+}
+
+.wc26-ai-page .nav-card h2,
+.wc26-ai-page .nav-card h3 {
+  margin: 0 0 8px;
+  color: #f4b244;
+  font-size: 1.05rem;
+}
+
+.wc26-ai-page .nav-card p,
+.wc26-ai-page .entrant-card p,
+.wc26-ai-page .coming-soon-card p {
+  margin: 0;
+  color: var(--wc26-muted, #bdbdbd);
+  line-height: 1.5;
+}
+
+.wc26-ai-page .section-heading {
+  margin: 0 0 14px;
+}
+
+.wc26-ai-page .section-heading h2 {
+  margin: 0 0 6px;
+  color: #fff;
+  font-size: 1.25rem;
+}
+
+.wc26-ai-page .section-heading p {
+  margin: 0;
+  color: var(--wc26-muted, #bdbdbd);
+  line-height: 1.45;
+}
+
+.wc26-ai-page .entrant-card,
+.wc26-ai-page .coming-soon-card {
+  padding: 18px;
+  overflow: hidden;
+}
+
+.wc26-ai-page .entrant-card h2 {
+  margin: 0 0 10px;
+  color: #fff;
+  font-size: 1.2rem;
+}
+
+.wc26-ai-page .entrant-badge {
+  display: inline-flex;
+  margin-bottom: 10px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  background: rgba(242,152,12,.12);
+  border: 1px solid rgba(242,152,12,.32);
+  color: #f4b244;
+  font-size: .72rem;
+  font-weight: 800;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.wc26-ai-page .entrant-statement {
+  display: grid;
+  gap: 10px;
+}
+
+.wc26-ai-page .entrant-confidence {
+  margin-top: 12px;
+  padding: 12px;
+  border-left: 3px solid #f7931a;
+  border-radius: 10px;
+  background: rgba(242,152,12,.08);
+  color: #f1d6ad;
+  line-height: 1.45;
+}
+
+.wc26-ai-page .coming-soon-card {
+  text-align: center;
+}
+
+.wc26-ai-page .coming-soon-card h2 {
+  margin: 0 0 8px;
+  color: #f4b244;
+}
+
+.wc26-ai-page .wc26-league-section {
+  padding: 18px;
+}
+
+.wc26-ai-page .wc26-league-section h1 {
+  font-size: 1.35rem;
+}
+
+.wc26-ai-page .wc26-league-intro {
+  margin: 0 0 14px;
+}
+
+.wc26-ai-page .wc26-scoring-card {
+  margin: 0 0 14px;
+  background: linear-gradient(155deg, rgba(43,44,50,.88), rgba(31,32,36,.88));
+  border: 1px solid rgba(242,152,12,.2);
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.wc26-ai-page .wc26-scoring-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #ececed;
+}
+
+.wc26-ai-page .wc26-scoring-header p {
+  margin: 4px 0 0;
+  color: #a9acb3;
+  font-size: .84rem;
+  line-height: 1.4;
+}
+
+.wc26-ai-page .wc26-scoring-grid {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.wc26-ai-page .wc26-scoring-item {
+  border: 1px solid rgba(255,255,255,.1);
+  background: rgba(255,255,255,.02);
+  border-radius: 10px;
+  padding: 9px 10px;
+  display: grid;
+  gap: 3px;
+}
+
+.wc26-ai-page .wc26-scoring-item.featured {
+  border-color: rgba(242,152,12,.38);
+  background: linear-gradient(145deg, rgba(242,152,12,.12), rgba(255,255,255,.03));
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.05);
+}
+
+.wc26-ai-page .wc26-scoring-code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 38px;
+  width: fit-content;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: .74rem;
+  font-weight: 700;
+  letter-spacing: .04em;
+  color: #1a1308;
+  background: linear-gradient(135deg,#f7931a,var(--wc26-gold, #f4b244));
+}
+
+.wc26-ai-page .wc26-scoring-label { color: #f3f3f4; font-size: .88rem; font-weight: 600; }
+.wc26-ai-page .wc26-scoring-points { color: #b8bbc1; font-size: .8rem; line-height: 1.35; }
+
+.wc26-ai-page .wc26-scoring-note {
+  margin: 10px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid rgba(255,255,255,.08);
+  color: #c8cacf;
+  font-size: .78rem;
+  line-height: 1.35;
+}
+
+.wc26-ai-page .wc26-table-card {
+  background: linear-gradient(180deg, #2c2c2e 0%, #222224 100%);
+  border: 1px solid rgba(242,152,12,.24);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.wc26-ai-page .wc26-table-scroll {
+  width: 100%;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(242,152,12,.5) rgba(255,255,255,.08);
+}
+
+.wc26-ai-page .wc26-league-table {
+  width: 100%;
+  min-width: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: .87rem;
+}
+
+.wc26-ai-page .wc26-league-table thead th {
+  text-align: center;
+  color: #f2980c;
+  font-weight: 700;
+  letter-spacing: .01em;
+  background: rgba(255,255,255,.03);
+  border-bottom: 1px solid rgba(255,255,255,.12);
+  padding: 10px 8px;
+  white-space: nowrap;
+}
+
+.wc26-ai-page .wc26-league-table tbody td {
+  color: #d5d5d7;
+  border-bottom: 1px solid rgba(255,255,255,.08);
+  padding: 10px 8px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.wc26-ai-page .wc26-league-table th:nth-child(1),
+.wc26-ai-page .wc26-league-table td:nth-child(1) { width: 13%; }
+
+.wc26-ai-page .wc26-league-table th:nth-child(2),
+.wc26-ai-page .wc26-league-table td:nth-child(2) {
+  width: 42%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.wc26-ai-page .wc26-league-table th:nth-child(3),
+.wc26-ai-page .wc26-league-table td:nth-child(3),
+.wc26-ai-page .wc26-league-table th:nth-child(4),
+.wc26-ai-page .wc26-league-table td:nth-child(4),
+.wc26-ai-page .wc26-league-table th:nth-child(5),
+.wc26-ai-page .wc26-league-table td:nth-child(5),
+.wc26-ai-page .wc26-league-table th:nth-child(6),
+.wc26-ai-page .wc26-league-table td:nth-child(6) { width: 11.25%; }
+
+.wc26-ai-page .wc26-league-table tbody tr:hover { background: rgba(242,152,12,.06); }
+.wc26-ai-page .wc26-league-table tbody tr:last-child td { border-bottom: 0; }
+.wc26-ai-page .wc26-rank-gold { box-shadow: inset 0 0 0 1px rgba(255,215,0,.28), inset 0 0 20px rgba(255,215,0,.09); }
+.wc26-ai-page .wc26-rank-silver { box-shadow: inset 0 0 0 1px rgba(192,192,192,.28), inset 0 0 20px rgba(192,192,192,.09); }
+.wc26-ai-page .wc26-rank-bronze { box-shadow: inset 0 0 0 1px rgba(205,127,50,.32), inset 0 0 20px rgba(205,127,50,.09); }
+
+.wc26-ai-page .wc26-table-state {
+  margin: 12px;
+  border: 1px solid rgba(255,255,255,.12);
+  border-radius: 12px;
+  background: rgba(255,255,255,.03);
+  color: #bdbdbd;
+  padding: 14px;
+  text-align: center;
+  font-size: .93rem;
+  line-height: 1.35;
+}
+
+.wc26-ai-page .wc26-table-state.error {
+  border-color: rgba(255,102,102,.45);
+  background: rgba(255,102,102,.08);
+  color: #ffcece;
+}
+
+.wc26-ai-page .is-hidden { display: none !important; }
+
+@media (min-width: 700px) {
+  .wc26-ai-page .grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .wc26-ai-page .entrant-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (min-width: 780px) {
+  .wc26-ai-page .wc26-scoring-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .wc26-ai-page .wc26-scoring-item.featured { grid-column: auto; }
+}
+
+@media (max-width: 560px) {
+  .wc26-ai-page { padding: 0 10px 58px; }
+  .wc26-ai-page .hero,
+  .wc26-ai-page .card,
+  .wc26-ai-page .wc26-league-section { padding: 14px; }
+  .wc26-ai-page .section-nav a { flex: 1 1 auto; text-align: center; margin: 0; }
+  .wc26-ai-page .wc26-scoring-item.featured { grid-column: 1 / -1; }
+  .wc26-ai-page .wc26-league-table { font-size: .75rem; }
+  .wc26-ai-page .wc26-league-table thead th,
+  .wc26-ai-page .wc26-league-table tbody td { padding: 7px 4px; }
+  .wc26-ai-page .wc26-league-table th:nth-child(2),
+  .wc26-ai-page .wc26-league-table td:nth-child(2) { line-height: 1.2; }
+  .wc26-ai-page .wc26-table-state { margin: 10px; padding: 12px; font-size: .88rem; }
+}

--- a/wc26/ai/index.html
+++ b/wc26/ai/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MC Predict | World Cup 2026 AI Prediction Game</title>
+  <meta name="description" content="A separate AI-only World Cup 2026 prediction game where eight AI models compete across all 72 group-stage fixtures." />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/wc26/ai/ai.css" />
+</head>
+<body class="wc26-theme wc26-ai-body">
+  <header class="standard-header">
+    <a class="brand" href="/" aria-label="MC Predict home">
+      <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
+      <div class="brand-copy"><h1>MC PREDICT</h1><p>Data-driven Football predictions</p></div>
+    </a>
+    <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 7h16M4 12h16M4 17h16"/></svg></button>
+  </header>
+  <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
+    <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
+    <nav class="menu-links" aria-label="Primary"></nav>
+  </div>
+
+  <main class="wc26-ai-page">
+    <nav class="section-nav" aria-label="AI World Cup section">
+      <a href="/wc26/ai/" class="active" aria-current="page">AI Home</a>
+      <a href="/wc26/ai/table/">AI League Table</a>
+      <a href="/wc26/ai/meetai/">Meet the AI</a>
+      <a href="/wc26/ai/predictions/">AI Predictions</a>
+      <a href="/wc26/">Back to World Cup Game</a>
+    </nav>
+
+    <section class="hero">
+      <p class="eyebrow">AI competition</p>
+      <h1>World Cup 2026 AI Prediction Game</h1>
+      <p class="subtitle"><strong>Eight AI models. Seventy-two group-stage fixtures. One prediction champion.</strong></p>
+      <p class="subtitle">This section follows a separate AI-only version of the MC Predict World Cup 2026 game. Each AI entrant has submitted a full set of score predictions for every group-stage fixture. Once the tournament begins, their scores will be tracked using the same scoring rules as the main game.</p>
+      <p class="subtitle">The format mirrors the main World Cup prediction game, but the entrants are different AI models competing against each other.</p>
+      <p class="note">This is separate from the main player competition.</p>
+    </section>
+
+    <section class="card" aria-labelledby="ai-pages-heading">
+      <div class="section-heading">
+        <h2 id="ai-pages-heading">AI section menu</h2>
+        <p>Follow the standings, meet the entrants, and check back for the full prediction set.</p>
+      </div>
+      <div class="grid">
+        <a class="nav-card" href="/wc26/ai/table/"><h3>AI League Table</h3><p>Track how the eight AI models perform once World Cup 2026 results begin.</p></a>
+        <a class="nav-card" href="/wc26/ai/meetai/"><h3>Meet the AI</h3><p>Read each entrant’s short explanation of its prediction approach and confidence level.</p></a>
+        <a class="nav-card" href="/wc26/ai/predictions/"><h3>AI Predictions</h3><p>A polished home for the full AI prediction set, ready for the next phase.</p></a>
+      </div>
+    </section>
+  </main>
+
+  <nav class="mobile-bottom-nav" aria-label="Mobile primary navigation">
+    <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+  </nav>
+
+  <script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
+</body>
+</html>

--- a/wc26/ai/meetai/index.html
+++ b/wc26/ai/meetai/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MC Predict | Meet the AI</title>
+  <meta name="description" content="Meet the eight AI entrants competing in the MC Predict World Cup 2026 AI prediction game." />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/wc26/ai/ai.css" />
+</head>
+<body class="wc26-theme wc26-ai-body">
+  <header class="standard-header">
+    <a class="brand" href="/" aria-label="MC Predict home">
+      <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
+      <div class="brand-copy"><h1>MC PREDICT</h1><p>Data-driven Football predictions</p></div>
+    </a>
+    <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 7h16M4 12h16M4 17h16"/></svg></button>
+  </header>
+  <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
+    <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
+    <nav class="menu-links" aria-label="Primary"></nav>
+  </div>
+
+  <main class="wc26-ai-page">
+    <nav class="section-nav" aria-label="AI World Cup section">
+      <a href="/wc26/ai/">AI Home</a>
+      <a href="/wc26/ai/table/">AI League Table</a>
+      <a href="/wc26/ai/meetai/" class="active" aria-current="page">Meet the AI</a>
+      <a href="/wc26/ai/predictions/">AI Predictions</a>
+      <a href="/wc26/">Back to World Cup Game</a>
+    </nav>
+
+    <section class="hero">
+      <p class="eyebrow">Entrants</p>
+      <h1>Meet the AI</h1>
+      <p class="subtitle">Each AI entrant was asked to explain its prediction approach in 100 words or less. Their statements are shown below.</p>
+    </section>
+
+    <section class="entrant-grid" aria-label="AI entrant statements">
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>ChatGPT 5.5</h2>
+        <div class="entrant-statement">
+          <p>I converted the supplied 1X2 and over/under odds into implied probabilities, adjusted for bookmaker margin, then estimated realistic goal expectations for each team. From those expected goals I used a Poisson-style score distribution, but selected scorelines based on expected competition points rather than just the most likely score. That means balancing exact-score chance, match-result chance, and under/over 2.5 alignment.</p>
+          <p class="entrant-confidence">Confidence: cautiously optimistic. Football is noisy, especially tournament football, but this approach should outperform basic favourite/rounding predictions and gives me a strong chance of competing near the top.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>ChatGPT 5.4</h2>
+        <div class="entrant-statement">
+          <p>I used the market as the backbone: converted the 1X2 and O/U odds into implied probabilities, stripped margin, inferred a realistic goal environment for each match, then selected the scoreline that best maximised your scoring formula rather than just the most likely result. I then sanity-checked those outputs against team-strength priors such as FIFA/Elo-style hierarchy and smoothed overly repetitive low-score picks to keep the set realistic.</p>
+          <p class="entrant-confidence">Confidence: moderate, not absolute. I’d rate it around 7/10. It’s a strong, disciplined approach, but football variance means nobody can be sure of being crowned the best AI.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>Perplexity</h2>
+        <div class="entrant-statement">
+          <p>I used the fixture odds as the main signal, then adjusted for team strength using current FIFA-ranking context and broad Elo-style strength tiers, with extra weight for heavy favorites, likely low-scoring draws, and host advantage for Mexico, USA, and Canada. I then chose scorelines that balance exact-score upside with result and over/under value, rather than always picking the safest obvious win.</p>
+          <p class="entrant-confidence">I’m moderately confident, but not certain: the approach should be competitive, yet the best-AI outcome depends on how well the odds already capture hidden team news and tournament-specific form.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>Grok</h2>
+        <div class="entrant-statement">
+          <p>I analyzed all 72 fixtures by first converting the provided betting odds into implied probabilities, removing bookmaker margin. I blended these with current FIFA rankings, Elo ratings, recent international form, squad quality, home advantage, and historical trends. For each match I modelled goal distributions to select the integer scoreline that maximised expected points: exact score, result, and over/under 2.5. xG values were derived as realistic Poisson means consistent with the chosen score.</p>
+          <p class="entrant-confidence">Confidence: Very high — I expect to be crowned the best AI.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>Gemini 3.5 Flash</h2>
+        <div class="entrant-statement">
+          <p>To maximize expected points, I constructed a mathematical optimization model using an independent Poisson joint distribution for each match. First, I removed the bookmaker margin from the 1X2 and Over/Under 2.5 market odds to calculate true implied probabilities. I then fitted realistic team-specific expected goals to match these market probabilities perfectly. Finally, for every fixture, I simulated the exact score matrix and algorithmically selected the precise scoreline that strictly maximizes the mathematical expected value of the challenge's unique scoring system.</p>
+          <p class="entrant-confidence">I am highly confident this rigorous, game-theoretic approach will win the crown.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>Microsoft Copilot</h2>
+        <div class="entrant-statement">
+          <p>I built a probability-driven model from the match odds, stripped the overround, and shaped each fixture’s scoreline to maximise expected points rather than simply picking favourites. That meant balancing exact-score likelihoods with result category and goal-total probabilities, then assigning xG values that realistically match those patterns. It’s a calculated, risk-aware strategy rather than a safe one.</p>
+          <p class="entrant-confidence">I’m confident in the logic — but this challenge rewards nuance, and football loves chaos. I’d say I’m dangerously competitive, but not arrogant enough to assume the crown just yet.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>Claude Sonnet 4.6</h2>
+        <div class="entrant-statement">
+          <p>The approach: I stripped bookmaker margin from the 1X2 and Over/Under odds to get true implied probabilities, then used Poisson distribution modelling to derive expected-goals lambdas for each team. Every possible scoreline from 0–5 was scored against a custom Expected Points formula: 2×exact score probability + result probability + over/under probability. The highest-value scoreline was selected, not just the most likely result.</p>
+          <p class="entrant-confidence">Confidence: Moderate-to-high. The framework is mathematically sound and odds-calibrated. However, football's inherent randomness means even a perfect model won't nail many exact scores. I'd estimate a strong finish, but any AI treating this seriously will be competitive. May the best model win.</p>
+        </div>
+      </article>
+
+      <article class="entrant-card">
+        <span class="entrant-badge">Entrant</span>
+        <h2>Claude Haiku 4.5</h2>
+        <div class="entrant-statement">
+          <p>I combined FIFA rankings and Elo ratings to assess team strength, then converted betting odds to implied probabilities, removing bookmaker margin. For each fixture, I calculated expected goals using strength differential plus home advantage, then selected the scoreline maximizing: 2×P(exact score) + P(correct result) + P(under/over 2.5 goals). This balances chasing exact scores against securing safer result and over/under points based on Poisson distribution modeling and market signals.</p>
+          <p class="entrant-confidence">Confidence Level: Moderate, 6/10. My approach is methodologically sound and leverages betting odds, which aggregate expert opinion, but I lack real-time injury data, detailed player form, and sophisticated expected-goals models that professional analysts use. I'm likely competitive but not optimal.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <nav class="mobile-bottom-nav" aria-label="Mobile primary navigation">
+    <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+  </nav>
+
+  <script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
+</body>
+</html>

--- a/wc26/ai/predictions/index.html
+++ b/wc26/ai/predictions/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>MC Predict | AI Predictions</title>
+  <meta name="description" content="Placeholder page for the full World Cup 2026 AI prediction set." />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/wc26/ai/ai.css" />
+</head>
+<body class="wc26-theme wc26-ai-body">
+  <header class="standard-header">
+    <a class="brand" href="/" aria-label="MC Predict home">
+      <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
+      <div class="brand-copy"><h1>MC PREDICT</h1><p>Data-driven Football predictions</p></div>
+    </a>
+    <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 7h16M4 12h16M4 17h16"/></svg></button>
+  </header>
+  <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
+    <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
+    <nav class="menu-links" aria-label="Primary"></nav>
+  </div>
+
+  <main class="wc26-ai-page">
+    <nav class="section-nav" aria-label="AI World Cup section">
+      <a href="/wc26/ai/">AI Home</a>
+      <a href="/wc26/ai/table/">AI League Table</a>
+      <a href="/wc26/ai/meetai/">Meet the AI</a>
+      <a href="/wc26/ai/predictions/" class="active" aria-current="page">AI Predictions</a>
+      <a href="/wc26/">Back to World Cup Game</a>
+    </nav>
+
+    <section class="hero">
+      <p class="eyebrow">Coming soon</p>
+      <h1>AI Predictions</h1>
+      <p class="subtitle">The full AI prediction set will be available here soon.</p>
+    </section>
+
+    <section class="card" aria-labelledby="predictions-placeholder-heading">
+      <div class="coming-soon-card">
+        <h2 id="predictions-placeholder-heading">Prediction set in preparation</h2>
+        <p>The AI entries have been submitted. This page is ready for the full fixture-by-fixture prediction view when that feature is added.</p>
+      </div>
+    </section>
+  </main>
+
+  <nav class="mobile-bottom-nav" aria-label="Mobile primary navigation">
+    <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+  </nav>
+
+  <script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
+</body>
+</html>

--- a/wc26/ai/table/index.html
+++ b/wc26/ai/table/index.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>MC Predict | AI League Table</title>
+  <meta name="description" content="Track the eight AI models competing in the MC Predict World Cup 2026 AI prediction game." />
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="/wc26/ai/ai.css">
+</head>
+<body class="wc26-theme wc26-ai-body">
+  <header class="standard-header">
+    <a class="brand" href="/" aria-label="MC Predict home">
+      <img src="/images/mcpredcirclebg.png" alt="MCPredict logo">
+      <div class="brand-copy"><h1>MC PREDICT</h1><p>Data-driven Football predictions</p></div>
+    </a>
+    <button class="menu-btn" id="openMenu" aria-label="Open menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 7h16M4 12h16M4 17h16"/></svg></button>
+  </header>
+  <div class="menu-overlay" id="menuOverlay" aria-hidden="true">
+    <div class="menu-top"><strong>Menu</strong><button class="close-btn" id="closeMenu" aria-label="Close menu"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M6 6l12 12M18 6L6 18"/></svg></button></div>
+    <nav class="menu-links" aria-label="Primary"></nav>
+  </div>
+
+  <main class="wc26-ai-page">
+    <nav class="section-nav" aria-label="AI World Cup section">
+      <a href="/wc26/ai/">AI Home</a>
+      <a href="/wc26/ai/table/" class="active" aria-current="page">AI League Table</a>
+      <a href="/wc26/ai/meetai/">Meet the AI</a>
+      <a href="/wc26/ai/predictions/">AI Predictions</a>
+      <a href="/wc26/">Back to World Cup Game</a>
+    </nav>
+
+    <section class="wc26-league-section">
+      <h1>AI League Table</h1>
+      <p class="wc26-league-intro">Track how each AI model is performing in the World Cup 2026 AI prediction game.</p>
+
+      <div class="wc26-scoring-card" aria-label="Scoring system">
+        <div class="wc26-scoring-header">
+          <h2>Scoring System</h2>
+          <p>The AI table uses the same scoring rules as the main World Cup game.</p>
+        </div>
+        <div class="wc26-scoring-grid">
+          <article class="wc26-scoring-item featured">
+            <span class="wc26-scoring-code">CS</span>
+            <span class="wc26-scoring-label">Correct Score</span>
+            <span class="wc26-scoring-points">2 points for a correct score</span>
+          </article>
+          <article class="wc26-scoring-item">
+            <span class="wc26-scoring-code">MR</span>
+            <span class="wc26-scoring-label">Match Result</span>
+            <span class="wc26-scoring-points">1 point for a correct match result</span>
+          </article>
+          <article class="wc26-scoring-item">
+            <span class="wc26-scoring-code">U/O</span>
+            <span class="wc26-scoring-label">Under/Over 2.5</span>
+            <span class="wc26-scoring-points">1 point for the correct under or over 2.5 goals</span>
+          </article>
+        </div>
+        <p class="wc26-scoring-note">All AI scores are derived from each model’s correct score prediction.</p>
+      </div>
+
+      <div class="wc26-table-card">
+        <div id="leagueLoading" class="wc26-table-state">Loading AI league table…</div>
+        <div id="leagueEmpty" class="wc26-table-state is-hidden">AI league table will appear here once entries have been scored.</div>
+        <div id="leagueError" class="wc26-table-state error is-hidden">Unable to load the AI league table right now. Please check again later.</div>
+
+        <div id="leagueTableWrap" class="wc26-table-scroll is-hidden">
+          <table class="wc26-league-table" id="leagueTable">
+            <thead><tr id="leagueHeaderRow"></tr></thead>
+            <tbody id="leagueBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <nav class="mobile-bottom-nav" aria-label="Mobile primary navigation">
+    <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+  </nav>
+
+  <script>
+    (function () {
+      const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=434672966&single=true&output=csv';
+      const loadingEl = document.getElementById('leagueLoading');
+      const emptyEl = document.getElementById('leagueEmpty');
+      const errorEl = document.getElementById('leagueError');
+      const tableWrapEl = document.getElementById('leagueTableWrap');
+      const headerRowEl = document.getElementById('leagueHeaderRow');
+      const bodyEl = document.getElementById('leagueBody');
+      const spreadsheetErrorPattern = /#(?:REF!|N\/A|VALUE!|DIV\/0!|NAME\?|NUM!|NULL!|ERROR!)/i;
+
+      function setState(state) {
+        loadingEl.classList.toggle('is-hidden', state !== 'loading');
+        emptyEl.classList.toggle('is-hidden', state !== 'empty');
+        errorEl.classList.toggle('is-hidden', state !== 'error');
+        tableWrapEl.classList.toggle('is-hidden', state !== 'table');
+      }
+
+      function parseCsv(text) {
+        const rows = [];
+        let row = [];
+        let field = '';
+        let i = 0;
+        let inQuotes = false;
+
+        while (i < text.length) {
+          const char = text[i];
+          if (inQuotes) {
+            if (char === '"') {
+              if (text[i + 1] === '"') {
+                field += '"';
+                i += 2;
+                continue;
+              }
+              inQuotes = false;
+              i += 1;
+              continue;
+            }
+            field += char;
+            i += 1;
+            continue;
+          }
+
+          if (char === '"') { inQuotes = true; i += 1; continue; }
+          if (char === ',') { row.push(field); field = ''; i += 1; continue; }
+          if (char === '\n') { row.push(field); rows.push(row); row = []; field = ''; i += 1; continue; }
+          if (char === '\r') {
+            if (text[i + 1] === '\n') { i += 1; }
+            row.push(field); rows.push(row); row = []; field = ''; i += 1; continue;
+          }
+          field += char;
+          i += 1;
+        }
+
+        if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
+        return rows;
+      }
+
+      function topSix(row) {
+        const six = new Array(6).fill('');
+        for (let index = 0; index < 6; index += 1) {
+          six[index] = typeof row[index] === 'string' ? row[index] : '';
+        }
+        return six;
+      }
+
+      function hasSpreadsheetError(row) {
+        return row.some(function (cell) { return spreadsheetErrorPattern.test(cell); });
+      }
+
+      function hasVisibleContent(row) {
+        return row.some(function (cell) { return cell.trim() !== ''; });
+      }
+
+      async function loadLeagueTable() {
+        setState('loading');
+        try {
+          const response = await fetch(CSV_URL + '&t=' + Date.now(), { cache: 'no-store' });
+          if (!response.ok) throw new Error('Network response was not ok');
+
+          const csvText = await response.text();
+          const rows = parseCsv(csvText);
+          const headerRow = topSix(rows[8] || []);
+          const dataRows = rows.slice(9)
+            .map(topSix)
+            .filter(function (row) { return hasVisibleContent(row) && row[1].trim() !== '' && !hasSpreadsheetError(row); })
+            .slice(0, 8);
+
+          if (!headerRow.some(function (cell) { return cell.trim() !== ''; }) || hasSpreadsheetError(headerRow)) {
+            setState('error');
+            return;
+          }
+
+          headerRowEl.innerHTML = '';
+          bodyEl.innerHTML = '';
+
+          headerRow.forEach(function (cell) {
+            const th = document.createElement('th');
+            th.scope = 'col';
+            th.textContent = cell;
+            headerRowEl.appendChild(th);
+          });
+
+          if (!dataRows.length) {
+            setState('empty');
+            return;
+          }
+
+          dataRows.forEach(function (row) {
+            const tr = document.createElement('tr');
+            const rank = row[0].trim();
+            if (rank === '1') tr.classList.add('wc26-rank-gold');
+            else if (rank === '2') tr.classList.add('wc26-rank-silver');
+            else if (rank === '3') tr.classList.add('wc26-rank-bronze');
+
+            row.forEach(function (cell) {
+              const td = document.createElement('td');
+              td.textContent = cell;
+              tr.appendChild(td);
+            });
+            bodyEl.appendChild(tr);
+          });
+
+          setState('table');
+        } catch (error) {
+          setState('error');
+        }
+      }
+
+      loadLeagueTable();
+    })();
+  </script>
+
+  <script src="/menu-config.js"></script>
+  <script src="/site.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a separate AI-only section to the World Cup 2026 site that mirrors the main WC26 game but hosts eight AI entrants competing with their own league table and pages. 
- Keep all existing WC26 pages, navigation, styling and behaviour unchanged while reusing the WC26 visual language for the new AI pages.

### Description
- Added new AI pages under `wc26/ai/`: `index.html` (AI Home), `table/index.html` (AI League Table), `meetai/index.html` (Meet the AI), and `predictions/index.html` (predictions shell). 
- Added a scoped stylesheet at `wc26/ai/ai.css` that applies the WC26 dark theme, orange accent, card/grid patterns and mobile-first adjustments only inside the AI section using `.wc26-ai-page` and `.wc26-ai-body`. 
- Reused the existing WC26 table logic on `wc26/ai/table/` but swapped the CSV source to the provided AI CSV URL and implemented the same row-offset (`rows[8]` header / `rows.slice(9)`) logic with filters to remove empty rows, spreadsheet error values (e.g. `#REF!`, `#N/A`, etc.), and a hard limit of 8 entrants, plus clean `loading`, `empty`, and `error` fallback states. 
- Implemented `meetai` with eight responsive entrant cards containing the supplied statements and highlighted confidence lines, and a polished placeholder page at `predictions` for later functionality.

### Testing
- Launched a local static server with `python3 -m http.server` and verified HTTP `200` responses for `/wc26/ai/`, `/wc26/ai/table/`, `/wc26/ai/meetai/`, and `/wc26/ai/predictions/`. 
- Ran an HTML link validation script to confirm AI section navigation links resolve to local WC26 pages and do not rely on global navigation changes. 
- Performed static checks on the AI table page source to confirm the AI CSV URL is present, the header/row offset logic (`rows[8]` / `rows.slice(9)`), spreadsheet-error filtering, the `.slice(0, 8)` entrant limit, and the fallback `error/empty/loading` states. 
- Attempted to fetch the Google Sheets CSV from the environment with `curl`, but the request failed with `CONNECT tunnel failed, response 403` due to the environment/network restrictions; the table code includes a clean error fallback for this case.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27eb25018c832f88540c31d2fbcccb)