### PR TITLE
Replace mobile footer FAQs with World Cup trophy link

### DIFF
--- a/Test.html
+++ b/Test.html
@@ -194,6 +194,16 @@
         fill: none;
         stroke-width: 1.8;
       }
+      .mobile-bottom-nav__icon--world-cup {
+        color: #f09300;
+        filter: drop-shadow(0 0 4px rgba(240,147,0,.35));
+        font-size: 20px;
+        line-height: 20px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        stroke: none;
+      }
       .mobile-bottom-nav__label {
         font-size: .72rem;
         line-height: 1;
@@ -219,6 +229,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body>
   <div class="container">
@@ -323,9 +334,9 @@
       <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V9M12 19V5M19 19v-7"/></svg>
       <span class="mobile-bottom-nav__label">Data</span>
     </a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs" aria-label="FAQs">
-      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg>
-      <span class="mobile-bottom-nav__label">FAQs</span>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup">
+      <i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i>
+      <span class="mobile-bottom-nav__label">World Cup</span>
     </a>
   </nav>
 

--- a/Test2.html
+++ b/Test2.html
@@ -781,9 +781,9 @@
       <span class="icon">📊</span>
       <span class="label">History</span>
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
     </a>
   </nav>
 

--- a/faqs.html
+++ b/faqs.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
   <link rel="stylesheet" href="style.css">
 
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body>
 
@@ -83,7 +84,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/hda-highchance.html
+++ b/hda-highchance.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body class="home prediction-page">
 <div class="prediction-shell">
@@ -69,7 +70,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/hda-histd.html
+++ b/hda-histd.html
@@ -776,9 +776,9 @@
       <span class="icon">📊</span>
       <span class="label">History</span>
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
     </a>
   </nav>
 
@@ -1085,7 +1085,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/hda-histf.html
+++ b/hda-histf.html
@@ -777,9 +777,9 @@
       <span class="icon">📊</span>
       <span class="label">History</span>
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
     </a>
   </nav>
 
@@ -1086,7 +1086,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/hda-results.html
+++ b/hda-results.html
@@ -451,6 +451,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 
 <body class="home">
@@ -537,9 +538,9 @@
       <span class="icon">📊</span>
       <span class="label">History</span>
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
     </a>
   </nav>
 

--- a/hda-value.html
+++ b/hda-value.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body class="home prediction-page">
 
@@ -70,7 +71,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/historical.html
+++ b/historical.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
 
 
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 
 <body class="home historical-page">
@@ -93,7 +94,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/index-old.html
+++ b/index-old.html
@@ -662,6 +662,7 @@
       }
     }
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 
 <body class="home">
@@ -912,9 +913,9 @@
       <span class="label">History</span>
 
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
 
     </a>
   </nav>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MC Predict</title>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
   <style>
     :root {
       --bg: #111214;
@@ -190,6 +191,16 @@
         fill: none;
         stroke-width: 1.8;
       }
+      .mobile-bottom-nav__icon--world-cup {
+        color: #f09300;
+        filter: drop-shadow(0 0 4px rgba(240,147,0,.35));
+        font-size: 20px;
+        line-height: 20px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        stroke: none;
+      }
       .mobile-bottom-nav__label {
         font-size: .72rem;
         line-height: 1;
@@ -323,9 +334,9 @@
       <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 19V9M12 19V5M19 19v-7"/></svg>
       <span class="mobile-bottom-nav__label">Data</span>
     </a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs" aria-label="FAQs">
-      <svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg>
-      <span class="mobile-bottom-nav__label">FAQs</span>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup">
+      <i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i>
+      <span class="mobile-bottom-nav__label">World Cup</span>
     </a>
   </nav>
 

--- a/lucky-dip.html
+++ b/lucky-dip.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
 
 
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 
 <body class="home">
@@ -67,7 +68,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/season-review-2025-26.html
+++ b/season-review-2025-26.html
@@ -36,6 +36,7 @@
     @media(max-width:700px){.season-chart-frame{height:360px;max-height:360px}.season-chart-frame--bar{height:320px;max-height:320px}}
     @media(min-width:800px){.article-panel{padding:22px}.controls{grid-template-columns:repeat(4,minmax(0,1fr))}.cards{grid-template-columns:repeat(4,minmax(0,1fr))}}
   </style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body class="home prediction-page">
 <div class="article-shell">
@@ -79,7 +80,7 @@
     <p class="links-bottom"><strong>Next links:</strong> <a href="/hda-value">Match Result Best Value</a> · <a href="/hda-highchance">Match Result Highest Probability</a> · <a href="/historical">Historical Data</a></p>
   </main>
 </div>
-<nav class="mobile-bottom-nav prediction-bottom-nav" aria-label="Mobile primary navigation"><a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a><a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a><a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a><a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a></nav>
+<nav class="mobile-bottom-nav prediction-bottom-nav" aria-label="Mobile primary navigation"><a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a><a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a><a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a><a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a></nav>
 <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 <script src="/season-review-2025-26.data.js"></script>

--- a/style.css
+++ b/style.css
@@ -857,7 +857,7 @@ body.home .table-container table {
 .mobile-bottom-nav{display:none}
 @media (max-width:767px){body{padding-bottom:calc(92px + env(safe-area-inset-bottom))}.mobile-bottom-nav{position:fixed;left:12px;right:12px;bottom:calc(10px + env(safe-area-inset-bottom));z-index:1000;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:4px;padding:6px;border-radius:20px;border:1px solid rgba(247,147,26,.22);background:rgba(24,26,30,.95);box-shadow:0 14px 28px rgba(0,0,0,.4);backdrop-filter:blur(10px)}
 .mobile-bottom-nav__item{min-height:58px;margin:0;padding:0;background:none;border:0;text-decoration:none;color:#9ba3af;border-radius:14px;display:inline-grid;justify-items:center;align-content:center;gap:4px}
-.mobile-bottom-nav__icon{width:20px;height:20px;stroke:#f7931a;fill:none;stroke-width:1.8}.mobile-bottom-nav__label{font-size:.72rem;font-weight:600}
+.mobile-bottom-nav__icon{width:20px;height:20px;stroke:#f7931a;fill:none;stroke-width:1.8}.mobile-bottom-nav__icon--world-cup{color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));font-size:20px;line-height:20px;display:inline-flex;align-items:center;justify-content:center;stroke:none}.mobile-bottom-nav__label{font-size:.72rem;font-weight:600}
 .mobile-bottom-nav__item--active{color:#f7931a;background:rgba(240,147,0,.08);box-shadow:0 0 14px rgba(240,147,0,.16)}}
 @media (min-width:768px){.mobile-bottom-nav{display:none!important}}
 @media (max-width:430px){

--- a/uo-highchance.html
+++ b/uo-highchance.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body class="home prediction-page">
 <div class="prediction-shell">
@@ -69,7 +70,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/uo-histd.html
+++ b/uo-histd.html
@@ -777,9 +777,9 @@
       <span class="icon">📊</span>
       <span class="label">History</span>
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
     </a>
   </nav>
 
@@ -1086,7 +1086,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/uo-histf.html
+++ b/uo-histf.html
@@ -777,9 +777,9 @@
       <span class="icon">📊</span>
       <span class="label">History</span>
     </a>
-    <a href="/faqs" data-key="faqs">
-      <span class="icon">❓</span>
-      <span class="label">FAQs</span>
+    <a href="https://www.mcpredict.com/wc26/" data-key="wc26" aria-label="World Cup">
+      <span class="icon"><i class="fas fa-trophy" aria-hidden="true" style="color:#f09300;filter:drop-shadow(0 0 4px rgba(240,147,0,.35));"></i></span>
+      <span class="label">World Cup</span>
     </a>
   </nav>
 
@@ -1086,7 +1086,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/uo-value.html
+++ b/uo-value.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Proxima+Nova:wght@400;700&display=swap">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body class="home prediction-page">
 <div class="prediction-shell">
@@ -69,7 +70,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/wc26/ai/index.html
+++ b/wc26/ai/index.html
@@ -6,6 +6,7 @@
   <title>MC Predict | World Cup 2026 AI Prediction Game</title>
   <meta name="description" content="A separate AI-only World Cup 2026 prediction game where eight AI models compete across all 72 group-stage fixtures." />
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
   <link rel="stylesheet" href="/wc26/ai/ai.css" />
 </head>
 <body class="wc26-theme wc26-ai-body">
@@ -56,7 +57,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/wc26/ai/meetai/index.html
+++ b/wc26/ai/meetai/index.html
@@ -6,6 +6,7 @@
   <title>MC Predict | Meet the AI</title>
   <meta name="description" content="Meet the eight AI entrants competing in the MC Predict World Cup 2026 AI prediction game." />
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
   <link rel="stylesheet" href="/wc26/ai/ai.css" />
 </head>
 <body class="wc26-theme wc26-ai-body">
@@ -115,7 +116,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>

--- a/wc26/ai/predictions/index.html
+++ b/wc26/ai/predictions/index.html
@@ -6,6 +6,7 @@
   <title>MC Predict | AI Predictions</title>
   <meta name="description" content="Explore every World Cup 2026 AI score prediction by fixture or by AI competitor." />
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
   <link rel="stylesheet" href="/wc26/ai/ai.css" />
   <style>
     .wc26-ai-page {
@@ -321,7 +322,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script>

--- a/wc26/ai/table/index.html
+++ b/wc26/ai/table/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Track the eight AI models competing in the MC Predict World Cup 2026 AI prediction game." />
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="/wc26/ai/ai.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
 </head>
 <body class="wc26-theme wc26-ai-body">
   <header class="standard-header">
@@ -79,7 +80,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script>

--- a/wc26/index.html
+++ b/wc26/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>MC Predict | World Cup 2026</title>
   <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"/>
   <style>
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(230px,1fr));gap:12px}
     .nav-card h3{margin:0 0 8px}
@@ -52,7 +53,7 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/hda-value" href="/hda-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M6 19h12M8 19V9h8v10M10 9V5h4v4"/></svg><span class="mobile-bottom-nav__label">Winner</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/uo-value" href="/uo-value"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg><span class="mobile-bottom-nav__label">U/O 2.5</span></a>
     <a class="mobile-bottom-nav__item" data-nav-path="/historical" href="/historical"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M5 19V9M12 19V5M19 19v-7"/></svg><span class="mobile-bottom-nav__label">Data</span></a>
-    <a class="mobile-bottom-nav__item" data-nav-path="/faqs" href="/faqs"><svg class="mobile-bottom-nav__icon" viewBox="0 0 24 24"><path d="M9.5 9a2.5 2.5 0 1 1 4.3 1.8c-.9.9-1.8 1.3-1.8 2.7"/><circle cx="12" cy="17" r=".8"/></svg><span class="mobile-bottom-nav__label">FAQs</span></a>
+    <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
   <script src="/menu-config.js"></script>


### PR DESCRIPTION
### Motivation
- Update the mobile sticky bottom navigation so the final item directs users to the World Cup 2026 content instead of the FAQs, using the same Font Awesome style as other icons. 
- Use a gold/orange trophy visual that matches the MCPredict accent (`#f09300`) and add a subtle glow while preserving existing size, spacing, alignment and behaviour. 
- Keep desktop navigation and all other links, layout and responsiveness unchanged. 

### Description
- Replaced the FAQs mobile footer anchor with a World Cup anchor linking to `https://www.mcpredict.com/wc26/` and labeled `World Cup` across the mobile footer instances in the site HTML. 
- The new icon uses the requested Font Awesome markup (`<i class="fas fa-trophy"></i>`) and a helper class `mobile-bottom-nav__icon--world-cup` so appearance matches other icons while allowing the trophy-specific styling. 
- Added the trophy styling (`color: #f09300; filter: drop-shadow(0 0 4px rgba(240,147,0,.35));`) into `style.css` and where necessary into inline page styles so the glow and sizing are applied without changing layout rules. 
- Injected the Font Awesome stylesheet where it was missing so the `fa-trophy` icon renders correctly, and set `data-nav-path="/wc26"` where appropriate so existing JS active-state handling continues to work. 

### Testing
- Ran a ripgrep search (`rg`) to verify occurrences of the old FAQs markup were removed and replaced, which returned no remaining FAQ bottom-nav instances in updated pages. (passed) 
- Executed a Python validation script to confirm every file that contains the trophy icon includes the `https://www.mcpredict.com/wc26/` href and a Font Awesome stylesheet reference, which completed without errors. (passed) 
- Ran `git diff --check` to ensure no whitespace/conflict markers were introduced, which returned clean. (passed) 
- Attempted a headless rendering / screenshot check using Playwright but it could not run because Playwright/browser tooling is not installed in this environment; visual QA should be validated in a browser. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2962d4c0e0832fa226a9eb5e290588)