### PR TITLE
Add “What Players Are Predicting” accordion to /wc26 homepage

### DIFF
--- a/wc26/index.html
+++ b/wc26/index.html
@@ -18,6 +18,47 @@
     .nav-card--ai h3 i{color:#7dd3fc;filter:drop-shadow(0 0 5px rgba(125,211,252,.35))}
     .nav-card--ai .ai-kicker{display:inline-flex;align-items:center;gap:6px;margin-bottom:8px;padding:4px 8px;border:1px solid rgba(125,211,252,.32);border-radius:999px;color:#bae6fd;background:rgba(14,165,233,.08);font-size:.72rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase}
     .nav-card--ai:hover,.nav-card--ai:focus-visible{border-color:rgba(125,211,252,.68);box-shadow:0 0 20px rgba(125,211,252,.16),0 12px 26px rgba(0,0,0,.28)}
+
+    .wc26-popular-section{position:relative;overflow:hidden;margin:0 auto 16px;padding:18px 14px 20px;border:1px solid rgba(244,178,68,.18);border-radius:20px;background:radial-gradient(circle at 50% 0%,rgba(244,178,68,.13),transparent 34%),linear-gradient(145deg,rgba(34,34,36,.96),rgba(18,19,22,.98));box-shadow:0 16px 36px rgba(0,0,0,.4),inset 0 1px 0 rgba(255,255,255,.05)}
+    .wc26-popular-section::before{content:"";position:absolute;inset:-90px -70px auto auto;width:180px;height:180px;border-radius:999px;background:radial-gradient(circle,rgba(240,147,0,.18),rgba(240,147,0,0) 70%);pointer-events:none}
+    .wc26-popular-header{position:relative;text-align:center;margin:0 auto 16px;max-width:760px}
+    .wc26-popular-pill{display:inline-flex;align-items:center;gap:8px;margin-bottom:10px;padding:7px 13px;border:1px solid rgba(240,147,0,.46);border-radius:999px;color:#f7c46d;background:rgba(240,147,0,.12);font-size:.76rem;font-weight:900;letter-spacing:.08em;text-transform:uppercase;box-shadow:0 0 18px rgba(240,147,0,.14)}
+    .wc26-popular-header h2{margin:0 0 8px;color:#fff;font-size:clamp(1.7rem,7vw,2.7rem);line-height:1.05;letter-spacing:-.04em;text-shadow:0 3px 18px rgba(0,0,0,.42)}
+    .wc26-popular-header p{margin:0;color:#c9d1dc;font-size:1rem;line-height:1.45}
+    .wc26-popular-accordion{position:relative;display:grid;gap:10px}
+    .wc26-popular-fixture{border:1px solid rgba(255,255,255,.11);border-radius:18px;background:linear-gradient(145deg,rgba(44,44,46,.82),rgba(25,26,29,.94));box-shadow:0 10px 24px rgba(0,0,0,.28);overflow:hidden}
+    .wc26-popular-fixture-toggle{width:100%;min-height:64px;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:14px 15px;border:0;color:#f5f5f5;background:transparent;text-align:left;cursor:pointer;font:inherit}
+    .wc26-popular-fixture-toggle:focus-visible{outline:2px solid rgba(244,178,68,.85);outline-offset:-4px;border-radius:18px}
+    .wc26-popular-toggle-copy{display:grid;gap:4px;min-width:0}
+    .wc26-popular-fixture-name{font-weight:900;font-size:1.02rem;line-height:1.2;white-space:normal}
+    .wc26-popular-preview{display:flex;flex-wrap:wrap;gap:6px;color:#bdbdbd;font-size:.82rem;line-height:1.25}
+    .wc26-popular-preview strong{color:#f4b244;font-weight:800}
+    .wc26-popular-chevron{flex:0 0 auto;color:#f4b244;transition:transform .22s ease;filter:drop-shadow(0 0 5px rgba(244,178,68,.22))}
+    .wc26-popular-fixture.is-open .wc26-popular-chevron{transform:rotate(180deg)}
+    .wc26-popular-fixture-panel{display:none;padding:0 12px 14px}
+    .wc26-popular-fixture.is-open .wc26-popular-fixture-panel{display:block}
+    .wc26-popular-match-card{margin:0 0 12px;padding:16px 12px;border:1px solid rgba(244,178,68,.16);border-radius:18px;background:radial-gradient(circle at 50% 0%,rgba(255,255,255,.08),transparent 48%),linear-gradient(145deg,rgba(31,34,38,.95),rgba(18,19,22,.96));text-align:center;box-shadow:inset 0 1px 0 rgba(255,255,255,.05)}
+    .wc26-popular-teams{display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);align-items:center;gap:10px}
+    .wc26-popular-team{display:flex;align-items:center;justify-content:center;min-height:58px;padding:10px 8px;border:1px solid rgba(255,255,255,.1);border-radius:15px;background:rgba(255,255,255,.035);color:#fff;font-size:1rem;font-weight:900;line-height:1.15}
+    .wc26-popular-vs{display:grid;place-items:center;width:44px;height:44px;border:1px solid rgba(244,178,68,.34);border-radius:999px;color:#f4b244;background:rgba(240,147,0,.09);font-weight:900;box-shadow:0 0 18px rgba(240,147,0,.13)}
+    .wc26-popular-block{margin-top:12px;padding:13px;border:1px solid rgba(255,255,255,.1);border-radius:17px;background:rgba(255,255,255,.028)}
+    .wc26-popular-block-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:12px}
+    .wc26-popular-block h3{display:flex;align-items:center;gap:9px;margin:0;color:#fff;font-size:1.04rem;line-height:1.2}
+    .wc26-popular-block-number{display:grid;place-items:center;width:31px;height:31px;border:1px solid rgba(240,147,0,.55);border-radius:999px;color:#f4b244;background:rgba(240,147,0,.08);font-size:.9rem;font-weight:900}
+    .wc26-popular-block-icon{color:#f09300;font-size:1.12rem}
+    .wc26-popular-score-grid{display:grid;grid-template-columns:1fr;gap:10px}
+    .wc26-popular-score-card{position:relative;display:grid;grid-template-columns:auto 1fr auto;align-items:center;gap:10px;padding:13px 12px;border:1px solid rgba(255,255,255,.12);border-radius:16px;background:linear-gradient(145deg,rgba(255,255,255,.055),rgba(255,255,255,.025));min-height:72px}
+    .wc26-popular-score-card.is-top{border-color:rgba(244,178,68,.82);background:radial-gradient(circle at 22% 0%,rgba(244,178,68,.22),transparent 48%),linear-gradient(145deg,rgba(48,41,24,.96),rgba(31,29,25,.98));box-shadow:0 0 18px rgba(244,178,68,.24),inset 0 1px 0 rgba(255,255,255,.07)}
+    .wc26-popular-rank{display:grid;place-items:center;width:34px;height:34px;border-radius:999px;color:#101010;background:linear-gradient(135deg,#f4b244,#ffd56e);font-weight:900;box-shadow:0 3px 12px rgba(244,178,68,.28)}
+    .wc26-popular-score-card:not(.is-top) .wc26-popular-rank{color:#1a1b1d;background:#aeb4bc;box-shadow:none}
+    .wc26-popular-scoreline{color:#fff;font-size:1.55rem;font-weight:950;letter-spacing:-.03em;line-height:1}
+    .wc26-popular-stat{text-align:right;display:grid;gap:3px}.wc26-popular-percent{color:#f4b244;font-size:1.28rem;font-weight:950;line-height:1}.wc26-popular-count{color:#bdbdbd;font-size:.78rem;font-weight:700}
+    .wc26-popular-results{display:grid;gap:10px}.wc26-popular-result-card{display:grid;gap:7px}.wc26-popular-result-top{display:flex;align-items:flex-end;justify-content:space-between;gap:10px;color:#f2f2f2;font-weight:850}.wc26-popular-result-label{min-width:0;overflow-wrap:anywhere}.wc26-popular-result-meta{flex:0 0 auto;color:#f4b244;font-weight:950}.wc26-popular-bar{height:13px;border-radius:999px;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.09);overflow:hidden}.wc26-popular-bar-fill{height:100%;max-width:100%;border-radius:999px;background:linear-gradient(90deg,#20964c,#43d06d);box-shadow:0 0 12px rgba(67,208,109,.22)}.wc26-popular-result-card.is-top .wc26-popular-bar-fill{background:linear-gradient(90deg,#f09300,#f4b244);box-shadow:0 0 14px rgba(244,178,68,.24)}
+    .wc26-popular-ou-card{position:relative;display:grid;grid-template-columns:1fr 1fr;border:1px solid rgba(255,255,255,.11);border-radius:17px;overflow:hidden;background:rgba(0,0,0,.18)}
+    .wc26-popular-ou-choice{display:grid;place-items:center;gap:4px;min-height:112px;padding:14px 8px;text-align:center}.wc26-popular-ou-choice:first-child{border-right:1px solid rgba(255,255,255,.1);background:radial-gradient(circle at 0% 0%,rgba(67,208,109,.13),transparent 56%)}.wc26-popular-ou-choice:last-child{background:radial-gradient(circle at 100% 0%,rgba(244,68,83,.14),transparent 56%)}.wc26-popular-ou-label{color:#fff;font-weight:900;font-size:.98rem}.wc26-popular-ou-percent{font-size:1.85rem;font-weight:950;line-height:1}.wc26-popular-ou-choice:first-child .wc26-popular-ou-percent{color:#43d06d}.wc26-popular-ou-choice:last-child .wc26-popular-ou-percent{color:#ff5465}.wc26-popular-ou-count{color:#bdbdbd;font-size:.78rem;font-weight:700}.wc26-popular-ou-vs{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);display:grid;place-items:center;width:48px;height:48px;border:1px solid rgba(255,255,255,.28);border-radius:999px;color:#fff;background:#25282c;font-weight:950;box-shadow:0 6px 18px rgba(0,0,0,.38)}
+    .wc26-popular-note{display:flex;gap:10px;align-items:flex-start;margin:12px 0 0;padding:12px 13px;border:1px solid rgba(255,255,255,.1);border-radius:16px;background:rgba(255,255,255,.035);color:#c7cbd2;line-height:1.45;font-size:.88rem}.wc26-popular-note i{margin-top:2px;color:#bdbdbd}.wc26-popular-state{padding:18px 14px;border:1px solid rgba(255,255,255,.1);border-radius:16px;background:rgba(255,255,255,.035);color:#cfd3da;text-align:center}.wc26-popular-skeleton{position:relative;overflow:hidden}.wc26-popular-skeleton::after{content:"";position:absolute;inset:0;transform:translateX(-100%);background:linear-gradient(90deg,transparent,rgba(255,255,255,.08),transparent);animation:wc26PopularShimmer 1.35s infinite}@keyframes wc26PopularShimmer{100%{transform:translateX(100%)}}
+    @media (min-width:720px){.wc26-popular-section{padding:24px;margin-bottom:18px}.wc26-popular-fixture-panel{padding:0 16px 16px}.wc26-popular-score-grid{grid-template-columns:repeat(3,1fr)}.wc26-popular-score-card{grid-template-columns:1fr;text-align:center;justify-items:center;min-height:150px}.wc26-popular-stat{text-align:center}.wc26-popular-scoreline{font-size:2.05rem}.wc26-popular-content-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}.wc26-popular-content-grid .wc26-popular-block:first-child{grid-column:1/-1}}
+    @media (max-width:540px){.wc26-page{padding-bottom:88px}.wc26-popular-section{margin-left:-2px;margin-right:-2px}.wc26-popular-header p{font-size:.95rem}.wc26-popular-block{padding:12px 10px}.wc26-popular-teams{gap:7px}.wc26-popular-team{font-size:.92rem}.wc26-popular-vs{width:38px;height:38px}.wc26-popular-scoreline{font-size:1.38rem}.wc26-popular-percent{font-size:1.12rem}}
   </style>
 
 </head><body class="wc26-theme">
@@ -45,6 +86,17 @@
     <span class="entry-closed">Entries closed</span>
     <p class="note">Entries closed at 11:59pm UK time on Wednesday 10th June 2026.</p>
   </section>
+
+  <section class="wc26-popular-section" aria-labelledby="wc26-popular-title">
+    <div class="wc26-popular-header">
+      <span class="wc26-popular-pill"><i class="fa-solid fa-lock" aria-hidden="true"></i> Entries Closed</span>
+      <h2 id="wc26-popular-title">What Players Are Predicting</h2>
+      <p>Based on all submitted predictions for the upcoming matches.</p>
+    </div>
+    <div id="wc26-popular-root" class="wc26-popular-accordion" aria-live="polite">
+      <div class="wc26-popular-state wc26-popular-skeleton">Loading popular selections...</div>
+    </div>
+  </section>
   <section class="card" style="padding:16px">
     <div class="grid">
       <a class="nav-card" href="/wc26/rules/"><h3>Rules / FAQs</h3><p>View the scoring rules, deadline details, and common questions.</p></a>
@@ -62,6 +114,208 @@
     <a class="mobile-bottom-nav__item" data-nav-path="/wc26" href="https://www.mcpredict.com/wc26/" aria-label="World Cup"><i class="mobile-bottom-nav__icon mobile-bottom-nav__icon--world-cup fas fa-trophy" aria-hidden="true"></i><span class="mobile-bottom-nav__label">World Cup</span></a>
   </nav>
 
+
+  <script>
+    (function () {
+      const csvUrl = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=923199168&single=true&output=csv';
+      const root = document.getElementById('wc26-popular-root');
+      if (!root) return;
+
+      function parseCsv(text) {
+        const rows = [];
+        let row = [];
+        let field = '';
+        let inQuotes = false;
+        for (let i = 0; i < text.length; i += 1) {
+          const char = text[i];
+          const next = text[i + 1];
+          if (char === '"') {
+            if (inQuotes && next === '"') {
+              field += '"';
+              i += 1;
+            } else {
+              inQuotes = !inQuotes;
+            }
+          } else if (char === ',' && !inQuotes) {
+            row.push(field);
+            field = '';
+          } else if ((char === '\n' || char === '\r') && !inQuotes) {
+            if (char === '\r' && next === '\n') i += 1;
+            row.push(field);
+            rows.push(row);
+            row = [];
+            field = '';
+          } else {
+            field += char;
+          }
+        }
+        if (field || row.length) {
+          row.push(field);
+          rows.push(row);
+        }
+        return rows;
+      }
+
+      function isBlankRow(row) {
+        return !row || row.every((cell) => !String(cell || '').trim());
+      }
+
+      function readItem(row) {
+        return {
+          label: String(row[1] || '').trim(),
+          count: String(row[2] || '').trim(),
+          percent: String(row[3] || '').trim()
+        };
+      }
+
+      function percentToNumber(value) {
+        return Math.min(100, Math.max(0, Number(String(value).replace('%', '').trim()) || 0));
+      }
+
+      function parseFixtures(rows) {
+        const rangeRows = rows.slice(82, 132).map((row) => [row[1], row[2], row[3], row[4]]);
+        const fixtures = [];
+        let i = 0;
+        while (i < rangeRows.length && fixtures.length < 4) {
+          const fixtureNumber = String(rangeRows[i][0] || '').trim();
+          const fixtureName = String(rangeRows[i][1] || '').trim();
+          if (!fixtureNumber || !fixtureName) {
+            i += 1;
+            continue;
+          }
+
+          const fixture = { number: fixtureNumber, name: fixtureName, scores: [], results: [], underOver: [] };
+          i += 1;
+          while (i < rangeRows.length && fixture.scores.length < 3) {
+            if (!isBlankRow(rangeRows[i]) && String(rangeRows[i][1] || '').trim()) fixture.scores.push(readItem(rangeRows[i]));
+            i += 1;
+          }
+          while (i < rangeRows.length && isBlankRow(rangeRows[i])) i += 1;
+          while (i < rangeRows.length && fixture.results.length < 3) {
+            if (!isBlankRow(rangeRows[i]) && String(rangeRows[i][1] || '').trim()) fixture.results.push(readItem(rangeRows[i]));
+            i += 1;
+          }
+          while (i < rangeRows.length && isBlankRow(rangeRows[i])) i += 1;
+          while (i < rangeRows.length && fixture.underOver.length < 2) {
+            if (!isBlankRow(rangeRows[i]) && String(rangeRows[i][1] || '').trim()) fixture.underOver.push(readItem(rangeRows[i]));
+            i += 1;
+          }
+          fixtures.push(fixture);
+        }
+        return fixtures;
+      }
+
+      function escapeHtml(value) {
+        return String(value || '').replace(/[&<>'"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char]));
+      }
+
+      function countText(count) {
+        if (!count) return '';
+        return `${escapeHtml(count)} ${Number(count) === 1 ? 'pick' : 'picks'}`;
+      }
+
+      function getTeams(name) {
+        const parts = String(name || '').split(' v ');
+        if (parts.length === 2) return parts.map((part) => part.trim());
+        return [name, 'Opponent'];
+      }
+
+      function renderFixture(fixture, index) {
+        const isOpen = index === 0;
+        const panelId = `wc26-popular-panel-${index}`;
+        const buttonId = `wc26-popular-toggle-${index}`;
+        const teams = getTeams(fixture.name);
+        const topScore = fixture.scores[0];
+        const topResult = fixture.results.reduce((best, item) => (percentToNumber(item.percent) > percentToNumber(best.percent) ? item : best), fixture.results[0] || {});
+        const scores = fixture.scores.map((score, scoreIndex) => `
+          <div class="wc26-popular-score-card${scoreIndex === 0 ? ' is-top' : ''}">
+            <span class="wc26-popular-rank">${scoreIndex + 1}</span>
+            <span class="wc26-popular-scoreline">${escapeHtml(score.label)}</span>
+            <span class="wc26-popular-stat"><span class="wc26-popular-percent">${escapeHtml(score.percent)}</span><span class="wc26-popular-count">${countText(score.count)}</span></span>
+          </div>`).join('');
+        const maxResult = Math.max.apply(null, fixture.results.map((item) => percentToNumber(item.percent)));
+        const results = fixture.results.map((result) => {
+          const percent = percentToNumber(result.percent);
+          return `<div class="wc26-popular-result-card${percent === maxResult ? ' is-top' : ''}">
+            <div class="wc26-popular-result-top"><span class="wc26-popular-result-label">${escapeHtml(result.label)}</span><span class="wc26-popular-result-meta">${escapeHtml(result.percent)} · ${countText(result.count)}</span></div>
+            <div class="wc26-popular-bar" aria-hidden="true"><div class="wc26-popular-bar-fill" style="width:${percent}%"></div></div>
+          </div>`;
+        }).join('');
+        const underOver = fixture.underOver.map((choice) => `<div class="wc26-popular-ou-choice">
+          <span class="wc26-popular-ou-label">${escapeHtml(choice.label)}</span>
+          <span class="wc26-popular-ou-percent">${escapeHtml(choice.percent)}</span>
+          <span class="wc26-popular-ou-count">${countText(choice.count)}</span>
+        </div>`).join('');
+
+        return `<article class="wc26-popular-fixture${isOpen ? ' is-open' : ''}">
+          <button id="${buttonId}" class="wc26-popular-fixture-toggle" type="button" aria-expanded="${isOpen}" aria-controls="${panelId}">
+            <span class="wc26-popular-toggle-copy">
+              <span class="wc26-popular-fixture-name">${escapeHtml(fixture.name)}</span>
+              <span class="wc26-popular-preview">Popular selections${topScore && topScore.label ? ` · <strong>${escapeHtml(topScore.label)} ${escapeHtml(topScore.percent)}</strong>` : ''}${topResult && topResult.label ? ` · ${escapeHtml(topResult.label)} ${escapeHtml(topResult.percent)}` : ''}</span>
+            </span>
+            <i class="wc26-popular-chevron fa-solid fa-chevron-down" aria-hidden="true"></i>
+          </button>
+          <div id="${panelId}" class="wc26-popular-fixture-panel" role="region" aria-labelledby="${buttonId}">
+            <div class="wc26-popular-match-card">
+              <div class="wc26-popular-teams">
+                <div class="wc26-popular-team">${escapeHtml(teams[0])}</div>
+                <div class="wc26-popular-vs">VS</div>
+                <div class="wc26-popular-team">${escapeHtml(teams[1])}</div>
+              </div>
+            </div>
+            <div class="wc26-popular-content-grid">
+              <section class="wc26-popular-block" aria-label="Most Popular Scores for ${escapeHtml(fixture.name)}">
+                <div class="wc26-popular-block-head"><h3><span class="wc26-popular-block-number">1</span> Most Popular Scores</h3><i class="wc26-popular-block-icon fa-solid fa-crown" aria-hidden="true"></i></div>
+                <div class="wc26-popular-score-grid">${scores || '<div class="wc26-popular-state">No scoreline data available.</div>'}</div>
+              </section>
+              <section class="wc26-popular-block" aria-label="Match Result for ${escapeHtml(fixture.name)}">
+                <div class="wc26-popular-block-head"><h3><span class="wc26-popular-block-number">2</span> Match Result</h3><i class="wc26-popular-block-icon fa-solid fa-bullseye" aria-hidden="true"></i></div>
+                <div class="wc26-popular-results">${results || '<div class="wc26-popular-state">No result data available.</div>'}</div>
+              </section>
+              <section class="wc26-popular-block" aria-label="Under or Over 2.5 Goals for ${escapeHtml(fixture.name)}">
+                <div class="wc26-popular-block-head"><h3><span class="wc26-popular-block-number">3</span> Under / Over 2.5 Goals</h3><i class="wc26-popular-block-icon fa-solid fa-chart-simple" aria-hidden="true"></i></div>
+                <div class="wc26-popular-ou-card">${underOver || '<div class="wc26-popular-state">No goals data available.</div>'}<span class="wc26-popular-ou-vs">VS</span></div>
+              </section>
+            </div>
+          </div>
+        </article>`;
+      }
+
+      function bindAccordion() {
+        root.querySelectorAll('.wc26-popular-fixture-toggle').forEach((button) => {
+          button.addEventListener('click', () => {
+            const fixture = button.closest('.wc26-popular-fixture');
+            const shouldOpen = !fixture.classList.contains('is-open');
+            root.querySelectorAll('.wc26-popular-fixture').forEach((item) => {
+              item.classList.remove('is-open');
+              const toggle = item.querySelector('.wc26-popular-fixture-toggle');
+              if (toggle) toggle.setAttribute('aria-expanded', 'false');
+            });
+            if (shouldOpen) {
+              fixture.classList.add('is-open');
+              button.setAttribute('aria-expanded', 'true');
+            }
+          });
+        });
+      }
+
+      fetch(csvUrl)
+        .then((response) => {
+          if (!response.ok) throw new Error(`CSV request failed: ${response.status}`);
+          return response.text();
+        })
+        .then((text) => {
+          const fixtures = parseFixtures(parseCsv(text));
+          if (fixtures.length !== 4) throw new Error(`Expected 4 fixtures, found ${fixtures.length}`);
+          root.innerHTML = fixtures.map(renderFixture).join('') + '<p class="wc26-popular-note"><i class="fa-solid fa-circle-info" aria-hidden="true"></i><span>Percentages reflect the share of all submitted predictions for each fixture. Totals may not add up to 100% due to rounding.</span></p>';
+          bindAccordion();
+        })
+        .catch((error) => {
+          console.error('Unable to load WC26 popular selections', error);
+          root.innerHTML = '<div class="wc26-popular-state">Popular selections are temporarily unavailable.</div>';
+        });
+    }());
+  </script>
   <script src="/menu-config.js"></script>
   <script src="/site.js"></script>
 </body></html>


### PR DESCRIPTION
### Motivation
- Add a mobile-first, dark-themed “What Players Are Predicting” / “Popular Selections” section to the existing WC26 homepage, placed below the Entries Closed hero and above the nav cards, to surface the most popular scorelines, results and U/O 2.5 splits for upcoming fixtures.

### Description
- Inserted a scoped `wc26-popular-*` section into `wc26/index.html` with mobile-first responsive CSS and dark/orange styling, rounded cards, soft glow accents and sensible desktop max-widths so the homepage layout and navigation remain unchanged.
- Implemented client-side CSV fetching and parsing from the provided Google Sheets URL and extracted rows `B83:E132` using `rows.slice(82, 132)` and dynamic block parsing to produce four fixtures (no fixtures hardcoded).
- Rendered an accessible accordion where the first fixture is open by default, others are collapsed, headers are full-width buttons using `aria-expanded` and `aria-controls`, a rotating chevron, and clicking one fixture closes the others.
- Expanded fixture panels show split team cards, a highlighted top score card plus two other score cards, match-result rows with proportional progress bars (percent → width), an Under/Over 2.5 comparison card, counts (optional) and the requested footer note; graceful loading and error states are included.

### Testing
- Ran a static JS syntax check with `node --check /tmp/wc26-script-0.js` which passed successfully.
- Executed a headless functional test `node /tmp/test-wc26-popular.js` that simulates the CSV and verifies the UI rendering logic produced exactly four fixtures with the first open and three collapsed (test passed).
- Attempted a live `curl` of the provided CSV from the container but the environment proxy blocked outbound `CONNECT` requests (`CONNECT tunnel failed, response 403`), so end-to-end network fetch could not be verified from this environment; the runtime code still fetches the public CSV URL in the browser.
- No browser/screenshot tool was available in the container to capture visual verification, so visual QA should be performed in a device/emulator to confirm mobile layout and fixed-bottom-nav spacing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a868e6344832fad603c59cd514179)