### PR TITLE
WC26: Update hero to live game messaging

### DIFF
--- a/wc26/index.html
+++ b/wc26/index.html
@@ -80,16 +80,13 @@
     <a href="/wc26/" class="active" aria-current="page">Menu</a><a href="/wc26/rules/">Rules</a><a href="/wc26/table/">League Table</a><a href="/wc26/predictions/">Predictions</a><a href="/wc26/ai/">AI Hub</a><a href="/wc26/halloffame/">Hall Of Fame</a>
   </nav>
   <section class="hero">
-    <h1>MC Predict World Cup 2026 Game</h1>
-    <p class="subtitle">Entries for the World Cup 2026 prediction game have now closed.</p>
-    <p class="subtitle">You can still view the rules, follow the league table, check submitted predictions, and explore the AI challenge.</p>
-    <span class="entry-closed">Entries closed</span>
-    <p class="note">Entries closed at 11:59pm UK time on Wednesday 10th June 2026.</p>
+    <h1>MC Predict World Cup 2026 Game Is Live</h1>
+    <p class="subtitle">The predictions are locked in. Follow the league table, browse submitted scores, and see how the AI challenge unfolds.</p>
+    <span class="entry-closed">Game live</span>
   </section>
 
   <section class="wc26-popular-section" aria-labelledby="wc26-popular-title">
     <div class="wc26-popular-header">
-      <span class="wc26-popular-pill"><i class="fa-solid fa-lock" aria-hidden="true"></i> Entries Closed</span>
       <h2 id="wc26-popular-title">What Players Are Predicting</h2>
       <p>Based on all submitted predictions for the upcoming matches.</p>
     </div>


### PR DESCRIPTION
### Motivation
- Reflect that the World Cup 2026 prediction game is now live and make the top hero section shorter and more action-oriented. 
- Keep the primary goal of encouraging users to scroll to the “What Players Are Predicting” section. 
- Limit the changes to the `/wc26` area and avoid altering layout, data fetching, styling, or navigation logic.

### Description
- Replaced the hero heading with `MC Predict World Cup 2026 Game Is Live` in `wc26/index.html`.
- Replaced the hero body with `The predictions are locked in. Follow the league table, browse submitted scores, and see how the AI challenge unfolds.`.
- Changed the hero status badge text from `Entries closed` to `Game live` while preserving the same badge style.
- Removed the hero deadline line `Entries closed at 11:59pm UK time on Wednesday 10th June 2026.` and removed the small `Entries Closed` badge from the “What Players Are Predicting” header.

### Testing
- Ran `python3` static copy assertions against `wc26/index.html` to confirm the updated and removed strings, which passed. 
- Served the site locally with `python3 -m http.server 4173 --bind 127.0.0.1` and verified `/wc26/` with `curl`, which returned the updated hero and section copy. 
- Ran `git diff --check` which reported no issues. 
- Attempted to install/run Playwright with `npx --yes playwright` for automated desktop/mobile screenshot checks, but the install failed due to an `npm` registry 403, so browser-based screenshots could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a8e6b9b20832fbe02c9ac47c7390d)