### PR TITLE
Add WC26 non-dismissible "Quick note" banner (fetches B2 from Google Sheets)

### DIFF
--- a/wc26/table/index.html
+++ b/wc26/table/index.html
@@ -27,6 +27,30 @@
     }
     .wc26-league-section h1 { margin: 0 0 10px; font-size: 1.35rem; }
     .wc26-league-intro { margin: 0 0 14px; color: #bdbdbd; line-height: 1.45; }
+    .wc26-game-update-banner {
+      margin: 0 0 14px;
+      border: 1px solid rgba(242,152,12,.34);
+      border-radius: 14px;
+      background: linear-gradient(145deg, rgba(242,152,12,.10), rgba(255,255,255,.035));
+      box-shadow: 0 0 18px rgba(242,152,12,.10), inset 0 0 0 1px rgba(255,255,255,.04);
+      padding: 12px 14px;
+    }
+    .wc26-game-update-label {
+      display: block;
+      margin: 0 0 5px;
+      color: #f4b244;
+      font-size: .76rem;
+      font-weight: 800;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    .wc26-game-update-text {
+      margin: 0;
+      color: #f3f4f6;
+      font-size: .94rem;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
     .wc26-scoring-card {
       margin: 0 0 14px;
       background: linear-gradient(155deg, rgba(43,44,50,.88), rgba(31,32,36,.88));
@@ -192,6 +216,8 @@
       .wc26-league-table th:nth-child(2),
       .wc26-league-table td:nth-child(2) { line-height: 1.2; }
       .wc26-table-state { margin: 10px; padding: 12px; font-size: .88rem; }
+      .wc26-game-update-banner { padding: 11px 12px; }
+      .wc26-game-update-text { font-size: .9rem; }
     }
   </style>
 </head>
@@ -216,6 +242,11 @@
     <section class="wc26-league-section">
       <h1>League Table</h1>
       <p class="wc26-league-intro">Follow the World Cup 2026 prediction game standings as entries are scored throughout the tournament.</p>
+
+      <div id="wc26GameUpdateBanner" class="wc26-game-update-banner is-hidden" aria-live="polite">
+        <strong class="wc26-game-update-label">Quick note</strong>
+        <p id="wc26GameUpdateText" class="wc26-game-update-text"></p>
+      </div>
 
       <div class="wc26-scoring-card" aria-label="Scoring system">
         <div class="wc26-scoring-header">
@@ -258,6 +289,74 @@
     </section>
   </main>
   <script>
+    (function () {
+      const GAME_UPDATE_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=14495960&single=true&output=csv';
+      const gameUpdateBannerEl = document.getElementById('wc26GameUpdateBanner');
+      const gameUpdateTextEl = document.getElementById('wc26GameUpdateText');
+
+      function parseGameUpdateCsv(text) {
+        const rows = [];
+        let row = [];
+        let field = '';
+        let i = 0;
+        let inQuotes = false;
+
+        while (i < text.length) {
+          const char = text[i];
+          if (inQuotes) {
+            if (char === '"') {
+              if (text[i + 1] === '"') {
+                field += '"';
+                i += 2;
+                continue;
+              }
+              inQuotes = false;
+              i += 1;
+              continue;
+            }
+            field += char;
+            i += 1;
+            continue;
+          }
+
+          if (char === '"') { inQuotes = true; i += 1; continue; }
+          if (char === ',') { row.push(field); field = ''; i += 1; continue; }
+          if (char === '\n') { row.push(field); rows.push(row); row = []; field = ''; i += 1; continue; }
+          if (char === '\r') {
+            if (text[i + 1] === '\n') { i += 1; }
+            row.push(field); rows.push(row); row = []; field = ''; i += 1; continue;
+          }
+          field += char;
+          i += 1;
+        }
+
+        if (field.length > 0 || row.length > 0) { row.push(field); rows.push(row); }
+        return rows;
+      }
+
+      async function loadGameUpdateMessage() {
+        try {
+          const response = await fetch(GAME_UPDATE_CSV_URL + '&t=' + Date.now(), { cache: 'no-store' });
+          if (!response.ok) throw new Error('Network response was not ok');
+
+          const csvText = await response.text();
+          const rows = parseGameUpdateCsv(csvText);
+          const message = rows[1] && typeof rows[1][1] === 'string' ? rows[1][1].trim() : '';
+
+          if (!message) return;
+
+          gameUpdateTextEl.textContent = message;
+          gameUpdateBannerEl.classList.remove('is-hidden');
+        } catch (error) {
+          if (window.console && typeof window.console.warn === 'function') {
+            window.console.warn('WC26 game update message unavailable.', error);
+          }
+        }
+      }
+
+      loadGameUpdateMessage();
+    })();
+
     (function () {
       const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=1983601487&single=true&output=csv';
       const UPDATED_CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vQnj0ijqFw0UVhYOounuFrNdreTFovKqTTbYnnVvq_12RRwYxN8atQE3PkQJJSbPaBiM9JQyCSCioiZ/pub?gid=767478415&single=true&output=csv';


### PR DESCRIPTION
### Motivation
- Surface short, non-dismissible game updates from a published Google Sheet cell near the top of the WC26 league table page. 
- The banner must be visually soft, follow the WC26 dark theme with gold accent, and must not interfere with existing table behaviour. 
- The banner must only appear when cell B2 contains non-empty trimmed text and otherwise stay hidden and fail silently.

### Description
- Added a dedicated, hidden-by-default banner container above the scoring card in `wc26/table/index.html` with isolated classes `wc26-game-update-banner`, `wc26-game-update-label`, and `wc26-game-update-text`.
- Added isolated CSS styles for the banner to match the WC26 dark theme and subtle gold/orange accent, including mobile adjustments, inside `wc26/table/index.html`.
- Added isolated JavaScript in `wc26/table/index.html` that fetches the published CSV, parses it safely with a CSV parser function, extracts row 2 column B (`B2`), uses `textContent` to insert plain text into the banner, and reveals the banner only when the trimmed value is non-empty.
- The fetch logic is wrapped in `try/catch`, does not block rendering, logs a console warning on failure, and otherwise leaves the banner hidden so it cannot break existing table loading or functionality.

### Testing
- Ran `node --check /tmp/wc26-table-script-1.js` to validate the injected inline script syntax; this check passed.
- Ran `git diff --check` to surface whitespace/format issues; this check passed.
- Attempted to fetch the remote CSV from this environment using `curl` (and a curl→python CSV parse) but the container received a `403` / CONNECT tunnel response so the external CSV could not be verified here; the code is implemented to silently hide the banner when the fetch fails or the cell is empty.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e96ecdb50832fb51afb5ca10c6922)