### PR TITLE
Add World Cup 2026 Hall of Fame entry

### DIFF
--- a/wc26/halloffame/index.html
+++ b/wc26/halloffame/index.html
@@ -38,6 +38,16 @@
 
     <section class='hof-grid' aria-label='MC Predict tournament winners'>
       <article class='tournament'>
+        <h2>World Cup 2026</h2>
+        <ul class='rankings'>
+          <li class='first'><span class='place'>1st 🥇</span><span class='name'>Mike Shepherd</span></li>
+          <li class='second'><span class='place'>2nd 🥈</span><span class='name'>Charlie Holt</span></li>
+          <li class='third'><span class='place'>3rd 🥉</span><span class='name'>Aaron Flanagan</span></li>
+          <li class='other'><span class='place'>4th</span><span class='name'>Chris Miller</span></li>
+        </ul>
+      </article>
+
+      <article class='tournament'>
         <h2>Euro 2024</h2>
         <ul class='rankings'>
           <li class='first'><span class='place'>1st 🥇</span><span class='name'>Aaron Crosbie</span></li>


### PR DESCRIPTION
### Motivation
- Add the World Cup 2026 winners to the Hall of Fame page while preserving the existing layout, styling, and chronological ordering.

### Description
- Inserted a new `article` block for `World Cup 2026` in `wc26/halloffame/index.html` using the existing `ul.rankings` structure and ranking classes and placed it before the `Euro 2024` entry; no other files or assets were modified.

### Testing
- Ran an HTML parser assertion against `wc26/halloffame/index.html`, started a local HTTP server and fetched `/wc26/halloffame/` to confirm the new entry (`Mike Shepherd`, `Charlie Holt`, `Aaron Flanagan`, `Chris Miller`) is present and appears before `Euro 2024`, ran `git diff --check`, and committed the change successfully, while an attempt to install `playwright` for screenshots failed due to an `npm` registry `403 Forbidden` but did not affect the HTML verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4233f3aba8832fb2516f08f70b5898)